### PR TITLE
Metodo per specificare i dati riguardo l'iscrizione a REA

### DIFF
--- a/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
@@ -44,6 +44,11 @@ class CedentePrestatore implements XmlSerializableInterface
         $this->iscrizioneRea = $iscrizioneRea;
     }
 
+    public function setIscrizioneRea(IscrizioneRea $iscrizioneRea)
+    {
+        $this->iscrizioneRea = $iscrizioneRea;
+    }
+
     /**
      * @param \XMLWriter $writer
      * @return \XMLWriter

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -17,6 +17,7 @@ use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGener
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CessionarioCommittente;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\DatiAnagrafici;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\Sede;
@@ -28,6 +29,8 @@ class FatturaElettronicaFactory
     protected $idTrasmittente;
     /** @var CedentePrestatore */
     protected $cedentePrestatore;
+    /** @var IscrizioneRea */
+    protected $IscrizioneRea;
     /** @var CessionarioCommittente */
     protected $cessionarioCommittente;
     /** @var string */
@@ -86,6 +89,11 @@ class FatturaElettronicaFactory
         if ($idTrasmittente) {
             $this->idTrasmittente = new IdTrasmittente($datiAnagrafici->idPaese, $datiAnagrafici->codiceFiscale);
         }
+    }
+
+    public function setIscrizioneRea(IscrizioneRea $iscrizioneRea)
+    {
+      $this->cedentePrestatore->setIscrizioneRea($iscrizioneRea);
     }
 
     public function setIntermediario(DatiAnagrafici $terzoIntermediario, $soggettoEmittente = 'TZ')
@@ -159,7 +167,8 @@ class FatturaElettronicaFactory
             $this->cedentePrestatore,
             $this->cessionarioCommittente,
             $this->terzoIntermediario,
-            $this->soggettoEmittente
+            $this->soggettoEmittente,
+            $this->iscrizioneRea
         );
         $datiBeniServizi = new FatturaElettronicaBody\DatiBeniServizi($linee, $datiRiepilogo);
         $fatturaElettronicaBody = new FatturaElettronicaBody(

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -30,7 +30,7 @@ class FatturaElettronicaFactory
     /** @var CedentePrestatore */
     protected $cedentePrestatore;
     /** @var IscrizioneRea */
-    protected $IscrizioneRea;
+    protected $iscrizioneRea;
     /** @var CessionarioCommittente */
     protected $cessionarioCommittente;
     /** @var string */


### PR DESCRIPTION
Semplice metodo per specificare l'iscrizione REA. Ho visto la necessità di farlo, in quanto il costrutto della classe `FatturaElettronicaFactory` prende già come terzo e quarto parametro i contatti del cedente.

PHP non è il mio linguaggio principale di programmazione e questa è anche la mia prima pull request, quindi sarò contento di ricevere qualche feedback o critica e ovviamente sperò anche che questa modifica sarà accettata :)