### PR TITLE
Removed BOM (byte order mark)

### DIFF
--- a/xsd/fattura_pa_1.2.1.xsd
+++ b/xsd/fattura_pa_1.2.1.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
 	xmlns="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"


### PR DESCRIPTION
Nel validatore di prestashop https://validator.prestashop.com il file xsd da errore per il fatto che c'è il BOM ![image](https://user-images.githubusercontent.com/44964509/50779494-c7f06a80-12a0-11e9-80a5-4615cecca974.png)
