### PR TITLE
Aggiunta possibilità di impostare l'idTrasmittente manualmente

### DIFF
--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -97,6 +97,14 @@ class FatturaElettronicaFactory
     }
 
     /**
+     * @param DatiTrasmissione\IdTrasmittente $idTrasmittente
+     */
+    public function setIdTrasmittente(IdTrasmittente $idTrasmittente)
+    {
+        $this->idTrasmittente = $idTrasmittente;
+    }
+    
+    /**
      * @param DatiAnagrafici $terzoIntermediario
      * @param string $soggettoEmittente
      */


### PR DESCRIPTION
In riferimento all'Issue #41, la pull request relativa per aggiungere la possibilità di impostare l'idTrasmittente manualmente nella classe FatturaElettronicaFactory.