### PR TITLE
Fix error use MagicFieldsTrait;

### DIFF
--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
@@ -16,8 +16,6 @@ use Deved\FatturaElettronica\XmlRepeatedBlock;
 
 class DatiPagamento extends XmlRepeatedBlock
 {
-    use MagicFieldsTrait;
-
     public $modalitaPagamento;
     public $dataScadenzaPagamento;
     public $importoPagamento;


### PR DESCRIPTION
removed `use MagicFieldsTrait;` because conflicts con the same row in XmlBlock.

error:
`
<br />
<b>Fatal error</b>:  Uncaught exception 'ErrorException' with message 'Deved\FatturaElettronica\XmlBlock and Deved\FatturaElettronica\Traits\MagicFieldsTrait define the same property ($xmlFields) in the composition of Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed' in /fakepath/lib/e-invoice/vendor/deved/fattura-elettronica/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php:80
Stack trace:
#0 /fakepath/lib/e-invoice/vendor/deved/fattura-elettronica/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php(80): errors_default_handler(2048, 'Deved\\FatturaEl...', '/fakepath/...', 80, Array)
#1 /fakepath/vendor/composer/ClassLoader.php(444): include('/fakepath/...')
#2 /fakepath/vendor/ in <b>/fakepath/vendor/klein/klein/src/Klein/Klein.php</b> on line <b>954</b><br />`