### PR TITLE
[git] Remove from dist zip unneded files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.github/
+docs/
+tests/
+.gitattributes
+.gitignore
+.travis.yml
+phpunit.xml.dist


### PR DESCRIPTION
Nel pacchetto zip scaricato dall'utente finale tramite Composer questi i file indicati nel `.gitattributes` possono essere ignorati