### PR TITLE
Feat: aggiunto "Natura" a Linea e DatiRiepilogo

### DIFF
--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo.php
@@ -25,6 +25,8 @@ class DatiRiepilogo implements XmlSerializableInterface, \Countable, \Iterator
     protected $imposta;
     /** @var string */
     protected $esigibilitaIVA = "I";
+    /** @var string */
+    protected $natura;
     /** @var DatiRiepilogo[] */
     protected $datiRiepilogoAggiuntivi = [];
     /** @var int  */
@@ -36,9 +38,15 @@ class DatiRiepilogo implements XmlSerializableInterface, \Countable, \Iterator
      * @param $aliquotaIVA
      * @param string $esigibilitaIVA
      * @param bool $imposta
+     * @param string $natura
      */
-    public function __construct($imponibileImporto, $aliquotaIVA, $esigibilitaIVA = "I", $imposta = false)
-    {
+    public function __construct(
+        $imponibileImporto,
+        $aliquotaIVA,
+        $esigibilitaIVA = "I",
+        $imposta = false,
+        $natura = null
+    ) {
         if ($imposta === false) {
             $this->imposta = ($imponibileImporto / 100) * $aliquotaIVA;
         } else {
@@ -47,6 +55,7 @@ class DatiRiepilogo implements XmlSerializableInterface, \Countable, \Iterator
         $this->imponibileImporto = $imponibileImporto;
         $this->aliquotaIVA = $aliquotaIVA;
         $this->esigibilitaIVA = $esigibilitaIVA;
+        $this->natura = $natura;
         $this->datiRiepilogoAggiuntivi[] = $this;
     }
 
@@ -58,14 +67,16 @@ class DatiRiepilogo implements XmlSerializableInterface, \Countable, \Iterator
     {
         /** @var DatiRiepilogo $block */
         foreach ($this as $block) {
-            $natura = $block->natura;
             $writer->startElement('DatiRiepilogo');
             $writer->writeElement('AliquotaIVA', fe_number_format($block->aliquotaIVA, 2));
             $block->writeXmlField('Natura', $writer);
             $writer->writeElement('ImponibileImporto', fe_number_format($block->imponibileImporto, 2));
             $writer->writeElement('Imposta', fe_number_format($block->imposta, 2));
-            if (!$natura) {
+            if ($block->esigibilitaIVA) {
                 $writer->writeElement('EsigibilitaIVA', $block->esigibilitaIVA);
+            }
+            if ($block->natura) {
+                $writer->writeElement('Natura', $block->natura);
             }
             $block->writeXmlFields($writer);
             $writer->endElement();

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -31,7 +31,8 @@ class Linea implements XmlSerializableInterface
     protected $prezzoUnitario;
     /** @var float */
     protected $aliquotaIva;
-
+    /** @var string */
+    protected $natura;
 
     /**
      * Linea constructor.
@@ -41,6 +42,7 @@ class Linea implements XmlSerializableInterface
      * @param float $quantita
      * @param string $unitaMisura
      * @param float $aliquotaIva
+     * @param string $natura
      */
     public function __construct(
         $descrizione,
@@ -48,7 +50,8 @@ class Linea implements XmlSerializableInterface
         $codiceArticolo = null,
         $quantita = null,
         $unitaMisura = 'pz',
-        $aliquotaIva = 22.00
+        $aliquotaIva = 22.00,
+        $natura = null
     ) {
         $this->codiceArticolo = $codiceArticolo;
         $this->descrizione = $descrizione;
@@ -56,6 +59,7 @@ class Linea implements XmlSerializableInterface
         $this->quantita = $quantita;
         $this->unitaMisura = $unitaMisura;
         $this->aliquotaIva = $aliquotaIva;
+        $this->natura = $natura;
     }
 
 
@@ -84,6 +88,9 @@ class Linea implements XmlSerializableInterface
         $writer->writeElement('PrezzoUnitario', fe_number_format($this->prezzoUnitario, 2));
         $writer->writeElement('PrezzoTotale', $this->prezzoTotale());
         $writer->writeElement('AliquotaIVA', fe_number_format($this->aliquotaIva, 2));
+        if ($this->natura) {
+            $writer->writeElement('Natura', $this->natura);
+        }
         $this->writeXmlFields($writer);
         $writer->endElement();
         return $writer;


### PR DESCRIPTION
Aggiunto il campo `Natura` al costruttore del blocco `DettaglioLinee` e `DatiRiepilogo`.
Tale valore è obbligatorio se il campo `AliquotaIVA` è zero.

Se `DatiRiepilogo` non è passato nel [costruttore](https://github.com/deved-it/fattura-elettronica/blob/master/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi.php#L34) di `DatiBeniServizi` viene calcolato senza tenere conto di tutti i parametri. Sarebbe da gestire anche [qui](https://github.com/deved-it/fattura-elettronica/blob/master/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi.php#L70).