### PR TITLE
Versione XML errata per fatture PA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.github/
+docs/
+tests/
+.gitattributes
+.gitignore
+.travis.yml
+phpunit.xml.dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ dist: precise
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.1.9]
 ### Fixed
 - DataScadenzaPagamento facoltativa in DatiPagamento
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- DataScadenzaPagamento facoltativa in DatiPagamento
+
 ## [1.1.8]
 ### Added
 - possibilità di specificare allegati (grazie manrix)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10] - 2019-02-05
+### Added 
+- Aggiunta possibilità di specificare DatiSAL e DatiVeicoli, pull request #51 by manrix
+
 ## [1.1.9]
 ### Fixed
 - DataScadenzaPagamento facoltativa in DatiPagamento

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.7]
+### Fixed
+- bug fix vari
+
 ## [1.1.6]
 ### Added
 - in FatturaElettronicaFactory aggiunta possibilità di settare l'IdTrasmittente

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Rimosso BOM (byte order mark) da xsd/fattura_pa_1.2.1.xsd
+
 ## [1.1.3]
 ### Added
 - Aggiunto blocco DatiGenerali/DatiContratto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Aggiunto metodo per verifica fattura con schema xsd dell'sdi
 
+### Fixed
+- Riga fattura senza quantità
+
 ## [1.1.0]
 ### Added
 - Righe fattura con aliquota diversa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5]
+### Added
+- Possibilità di aggiungere blocchi multipli per il pagamento
+
 ## [1.1.4]
 ### Added
 - Possibilità di aggiungere nome e cognome in dati anagrafici in alternativa a denominazione (con proprietà dinamiche)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6]
+### Added
+- in FatturaElettronicaFactory aggiunta possibilità di settare l'IdTrasmittente
+
 ## [1.1.5]
 ### Added
 - Possibilità di aggiungere blocchi multipli per il pagamento

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8]
+### Added
+- possibilità di specificare allegati (grazie manrix)
+
 ## [1.1.7]
 ### Fixed
 - bug fix vari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3]
+### Added
+- Aggiunto blocco DatiGenerali/DatiContratto
+
+### Fixed
+- Diversi bug fixes
+- Reso opzionale il CodiceFIscale nei DatiAnagrafici
+
 ## [1.1.2]
 ### Added
 - Aggiunto metodo per verifica fattura con schema xsd dell'sdi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.1.4]
+### Added
+- Possibilità di aggiungere nome e cognome in dati anagrafici in alternativa a denominazione (con proprietà dinamiche)
 ### Fixed
 - Rimosso BOM (byte order mark) da xsd/fattura_pa_1.2.1.xsd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 ### Added
 - Aggiunto metodo per verifica fattura con schema xsd dell'sdi
+- Possibilità di aggiungere i campi DataInizioPeriodo e DataFinePeriodo
+- Possibilità di aggiungere il blocco DatiGenerali => DatiDDT
+- Possibilità di testare la validità del file XML
 
 ### Fixed
 - Riga fattura senza quantità

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.1.2]
 ### Added
 - Aggiunto metodo per verifica fattura con schema xsd dell'sdi
 - Possibilità di aggiungere i campi DataInizioPeriodo e DataFinePeriodo
 - Possibilità di aggiungere il blocco DatiGenerali => DatiDDT
-- Possibilità di testare la validità del file XML
+- Possibilità di aggiungere IscrizioneRea
 
 ### Fixed
 - Riga fattura senza quantità
+- DatiPagamento opzionali
 
 ## [1.1.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I casi particolari non sono stati ancora trattati.
 Potete segnalare qualsiasi necessità o problema 
 [qui](https://github.com/deved-it/fattura-elettronica/issues/new).
 
-## installazione
+## Installazione
 
     composer require deved/fattura-elettronica
     

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "ext-xmlwriter": "^7.1",
+        "ext-xmlwriter": "*",
         "ext-libxml": "*",
         "ext-dom": "*",
         "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
             "name": "Salvatore Guarino",
             "email": "sg@deved.it",
             "homepage": "http://www.deved.it"
-        },
-        {
-          "name": "Francesco Lovecchio",
-          "email": "francescolovecchio97@gmail.com",
-          "homepage": "https://www.linkedin.com/in/francescolovecchio/",
-          "role": "Developer"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
             "name": "Salvatore Guarino",
             "email": "sg@deved.it",
             "homepage": "http://www.deved.it"
+        },
+        {
+          "name": "Francesco Lovecchio",
+          "email": "francescolovecchio97@gmail.com",
+          "homepage": "https://www.linkedin.com/in/francescolovecchio/",
+          "role": "Developer"
         }
     ],
     "autoload": {

--- a/src/FatturaAdapter.php
+++ b/src/FatturaAdapter.php
@@ -122,4 +122,14 @@ class FatturaAdapter implements FatturaElettronicaInterface
     {
         $this->fatturaElettronicaHeader->cedentePrestatore->setIscrizioneRea($iscrizioneRea);
     }
+
+    /**
+     * Verifica l'xml della fattura
+     * @return bool
+     * @throws \Exception
+     */
+    public function verifica()
+    {
+        return $this->fatturaElettronica->verifica();
+    }
 }

--- a/src/FatturaAdapter.php
+++ b/src/FatturaAdapter.php
@@ -14,6 +14,7 @@ namespace Deved\FatturaElettronica;
 
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea;
 use Deved\FatturaElettronica\IntermediarioInterface;
 
 class FatturaAdapter implements FatturaElettronicaInterface
@@ -28,6 +29,10 @@ class FatturaAdapter implements FatturaElettronicaInterface
     public $fatturaElettronica;
     /** @var XmlFactory */
     protected $xmlFactory;
+    /** @var FatturaElettronicaHeader */
+    protected $fatturaElettronicaHeader;
+    /** @var FatturaElettronicaBody */
+    protected $fatturaElettronicaBody;
 
 
     /**
@@ -56,21 +61,21 @@ class FatturaAdapter implements FatturaElettronicaInterface
             $terzoIntermediario = $this->fattura->getAnagraficaIntermediario();
             $soggettoEmittente = $this->fattura->getSoggettoEmittente();
         }
-        $fatturaElettronicaHeader = new FatturaElettronicaHeader(
+        $this->fatturaElettronicaHeader = new FatturaElettronicaHeader(
             $this->fattura->getDatiTrasmissione(),
             $this->cedentePrestatore,
             $this->cessionarioCommittente,
             $terzoIntermediario,
             $soggettoEmittente
         );
-        $fatturaElettronicaBody = new FatturaElettronicaBody(
+        $this->fatturaElettronicaBody = new FatturaElettronicaBody(
             $this->fattura->getDatiGenerali(),
             $this->fattura->getDatiBeniServizi(),
             $this->fattura->getDatiPagamento()
         );
         $this->fatturaElettronica = new FatturaElettronica(
-            $fatturaElettronicaHeader,
-            $fatturaElettronicaBody,
+            $this->fatturaElettronicaHeader,
+            $this->fatturaElettronicaBody,
             $this->xmlFactory
         );
     }
@@ -107,5 +112,14 @@ class FatturaAdapter implements FatturaElettronicaInterface
     public function getFileName()
     {
         return $this->fatturaElettronica->getFileName();
+    }
+
+    /**
+     * @param IscrizioneRea $iscrizioneRea
+     * @return mixed
+     */
+    public function setIscrizioneRea(IscrizioneRea $iscrizioneRea)
+    {
+        $this->fatturaElettronicaHeader->cedentePrestatore->setIscrizioneRea($iscrizioneRea);
     }
 }

--- a/src/FatturaElettronica.php
+++ b/src/FatturaElettronica.php
@@ -13,8 +13,9 @@ namespace Deved\FatturaElettronica;
 
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea;
 
-class FatturaElettronica implements XmlSerializableInterface
+class FatturaElettronica implements XmlSerializableInterface, FatturaElettronicaInterface
 {
     /** @var FatturaElettronicaHeader */
     protected $fatturaElettronicaHeader;
@@ -95,5 +96,14 @@ class FatturaElettronica implements XmlSerializableInterface
             throw new \Exception(json_encode($this->xmlValidator->errors));
         }
         return $isValid;
+    }
+
+    /**
+     * @param IscrizioneRea $iscrizioneRea
+     * @return mixed
+     */
+    public function setIscrizioneRea(IscrizioneRea $iscrizioneRea)
+    {
+        $this->fatturaElettronicaHeader->cedentePrestatore->setIscrizioneRea($iscrizioneRea);
     }
 }

--- a/src/FatturaElettronica/FatturaElettronicaBody.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody.php
@@ -15,6 +15,7 @@ use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Allegato;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiVeicoli;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
 class FatturaElettronicaBody implements XmlSerializableInterface
@@ -28,6 +29,8 @@ class FatturaElettronicaBody implements XmlSerializableInterface
     protected $datiPagamento;
     /** @var Allegato  */
     protected $allegato;
+    /** @var DatiVeicoli  */
+    protected $datiVeicoli;
 
     /**
      * FatturaElettronicaBody constructor.
@@ -39,12 +42,14 @@ class FatturaElettronicaBody implements XmlSerializableInterface
         DatiGenerali $datiGenerali,
         DatiBeniServizi $datiBeniServizi,
         DatiPagamento $datiPagamento = null,
-        Allegato $allegato = null
+        Allegato $allegato = null,
+        DatiVeicoli $datiVeicoli = null
     ) {
         $this->datGenerali = $datiGenerali;
         $this->datiBeniServizi = $datiBeniServizi;
         $this->datiPagamento = $datiPagamento;
         $this->allegato = $allegato;
+        $this->datiVeicoli = $datiVeicoli;
     }
 
     /**
@@ -56,6 +61,9 @@ class FatturaElettronicaBody implements XmlSerializableInterface
         $writer->startElement('FatturaElettronicaBody');
             $this->datGenerali->toXmlBlock($writer);
             $this->datiBeniServizi->toXmlBlock($writer);
+            if ($this->datiVeicoli) {
+                $this->datiVeicoli->toXmlBlock($writer);
+            }
             if ($this->datiPagamento) {
                 $this->datiPagamento->toXmlBlock($writer);
             }

--- a/src/FatturaElettronica/FatturaElettronicaBody.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody.php
@@ -11,6 +11,7 @@
 
 namespace Deved\FatturaElettronica\FatturaElettronica;
 
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Allegato;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
@@ -25,6 +26,8 @@ class FatturaElettronicaBody implements XmlSerializableInterface
     protected $datiBeniServizi;
     /** @var DatiPagamento  */
     protected $datiPagamento;
+    /** @var Allegato  */
+    protected $allegato;
 
     /**
      * FatturaElettronicaBody constructor.
@@ -35,11 +38,13 @@ class FatturaElettronicaBody implements XmlSerializableInterface
     public function __construct(
         DatiGenerali $datiGenerali,
         DatiBeniServizi $datiBeniServizi,
-        DatiPagamento $datiPagamento = null
+        DatiPagamento $datiPagamento = null,
+        Allegato $allegato = null
     ) {
         $this->datGenerali = $datiGenerali;
         $this->datiBeniServizi = $datiBeniServizi;
         $this->datiPagamento = $datiPagamento;
+        $this->allegato = $allegato;
     }
 
     /**
@@ -53,6 +58,9 @@ class FatturaElettronicaBody implements XmlSerializableInterface
             $this->datiBeniServizi->toXmlBlock($writer);
             if ($this->datiPagamento) {
                 $this->datiPagamento->toXmlBlock($writer);
+            }
+            if ($this->allegato) {
+                $this->allegato->toXmlBlock($writer);
             }
         $writer->endElement();
         return $writer;

--- a/src/FatturaElettronica/FatturaElettronicaBody.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody.php
@@ -18,6 +18,7 @@ use Deved\FatturaElettronica\XmlSerializableInterface;
 
 class FatturaElettronicaBody implements XmlSerializableInterface
 {
+    const FE_CODE = 2.0;
     /** @var DatiGenerali  */
     public $datGenerali;
     /** @var DatiBeniServizi  */

--- a/src/FatturaElettronica/FatturaElettronicaBody.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody.php
@@ -18,7 +18,7 @@ use Deved\FatturaElettronica\XmlSerializableInterface;
 
 class FatturaElettronicaBody implements XmlSerializableInterface
 {
-    const FE_CODE = 2.0;
+    const FE_CODE = '2.0';
     /** @var DatiGenerali  */
     public $datGenerali;
     /** @var DatiBeniServizi  */

--- a/src/FatturaElettronica/FatturaElettronicaBody.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody.php
@@ -35,7 +35,7 @@ class FatturaElettronicaBody implements XmlSerializableInterface
     public function __construct(
         DatiGenerali $datiGenerali,
         DatiBeniServizi $datiBeniServizi,
-        DatiPagamento $datiPagamento
+        DatiPagamento $datiPagamento = null
     ) {
         $this->datGenerali = $datiGenerali;
         $this->datiBeniServizi = $datiBeniServizi;
@@ -51,7 +51,9 @@ class FatturaElettronicaBody implements XmlSerializableInterface
         $writer->startElement('FatturaElettronicaBody');
             $this->datGenerali->toXmlBlock($writer);
             $this->datiBeniServizi->toXmlBlock($writer);
-            $this->datiPagamento->toXmlBlock($writer);
+            if ($this->datiPagamento) {
+                $this->datiPagamento->toXmlBlock($writer);
+            }
         $writer->endElement();
         return $writer;
     }

--- a/src/FatturaElettronica/FatturaElettronicaBody/Allegato.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/Allegato.php
@@ -11,7 +11,6 @@
 
 namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 
-use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlRepeatedBlock;
 
 class Allegato extends XmlRepeatedBlock
@@ -51,7 +50,7 @@ class Allegato extends XmlRepeatedBlock
      */
     public function toXmlBlock(\XMLWriter $writer)
     {
-        /** @var Allegati $block */
+        /** @var Allegato $block */
         foreach ($this->blocks as $block) {
             $writer->startElement('Allegati');
             $writer->writeElement('NomeAttachment', $block->nomeAttachment);

--- a/src/FatturaElettronica/FatturaElettronicaBody/Allegato.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/Allegato.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlRepeatedBlock;
+
+class Allegato extends XmlRepeatedBlock
+{
+    public $nomeAttachment;
+    public $algoritmoCompressione;
+    public $formatoAttachment;
+    public $descrizioneAttachment;
+    public $attachment;
+
+    /**
+     * Allegati constructor.
+     * @param string $nomeAttachment
+     * @param string $attachment
+     * @param string | null $algoritmoCompressione
+     * @param string | null $formatoAttachment
+     * @param string | null $descrizioneAttachment
+     */
+    public function __construct(
+        $nomeAttachment,
+        $attachment,
+        $formatoAttachment = null,
+        $algoritmoCompressione = null,
+        $descrizioneAttachment = null
+    ) {
+        $this->nomeAttachment = $nomeAttachment;
+        $this->algoritmoCompressione = $algoritmoCompressione;
+        $this->formatoAttachment = $formatoAttachment;
+        $this->descrizioneAttachment = $descrizioneAttachment;
+        $this->attachment = $attachment;
+        parent::__construct();
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        /** @var Allegati $block */
+        foreach ($this->blocks as $block) {
+            $writer->startElement('Allegati');
+            $writer->writeElement('NomeAttachment', $block->nomeAttachment);
+            if ($block->algoritmoCompressione) {
+                $writer->writeElement('AlgoritmoCompressione', $block->algoritmoCompressione);
+            }
+            if ($block->formatoAttachment) {
+                $writer->writeElement('FormatoAttachment', $block->formatoAttachment);
+            }
+            if ($block->descrizioneAttachment) {
+                $writer->writeElement('DescrizioneAttachment', $block->descrizioneAttachment);
+            }
+            $writer->writeElement('Attachment', base64_encode($block->attachment));
+            $block->writeXmlFields($writer);
+            $writer->endElement();
+        }
+        return $writer;
+    }
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo.php
@@ -28,7 +28,7 @@ class DatiRiepilogo implements XmlSerializableInterface, \Countable, \Iterator
     /** @var DatiRiepilogo[] */
     protected $datiRiepilogoAggiuntivi = [];
     /** @var int  */
-    private $currentIndex = 0;
+    protected $currentIndex = 0;
 
     /**
      * DatiRiepilogo constructor.

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -95,11 +95,11 @@ class Linea implements XmlSerializableInterface
      */
     public function prezzoTotale($format = true)
     {
+        $quantita = $this->quantita ? $this->quantita : 1;
         if ($format) {
-            $quantita = $this->quantita ? $this->quantita : 1;
             return fe_number_format($this->prezzoUnitario * $quantita, 2);
         }
-        return $this->prezzoUnitario * $this->quantita;
+        return $this->prezzoUnitario * $quantita;
     }
 
     /**

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -79,6 +79,8 @@ class Linea implements XmlSerializableInterface
             $writer->writeElement('Quantita', fe_number_format($this->quantita, 2));
             $writer->writeElement('UnitaMisura', $this->unitaMisura);
         }
+        $this->writeXmlField('DataInizioPeriodo', $writer);
+        $this->writeXmlField('DataFinePeriodo', $writer);
         $writer->writeElement('PrezzoUnitario', fe_number_format($this->prezzoUnitario, 2));
         $writer->writeElement('PrezzoTotale', $this->prezzoTotale());
         $writer->writeElement('AliquotaIVA', fe_number_format($this->aliquotaIva, 2));

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -74,11 +74,11 @@ class DatiGenerali implements XmlSerializableInterface
                     'ImportoTotaleDocumento',
                     fe_number_format($this->importoTotaleDocumento, 2)
                 );
-                if ($this->datiDdt) {
-                    $this->datiDdt->toXmlBlock($writer);
-                }
                 $this->writeXmlFields($writer);
             $writer->endElement();
+            if ($this->datiDdt) {
+                $this->datiDdt->toXmlBlock($writer);
+            }
         $writer->endElement();
         //todo: implementare DatiOrdineAcquisto, DatiContratto etc. (facoltativi)
         return $writer;

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -13,6 +13,8 @@ namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiContratto;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiDdt;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiRitenuta;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiCassaPrevidenziale;
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
@@ -33,6 +35,11 @@ class DatiGenerali implements XmlSerializableInterface
     protected $datiDdt;
     /** @var DatiContratto */
     protected $datiContratto;
+    /** @var DatiRitenuta */
+    protected $datiRitenuta;
+    /** @var DatiCassaPrevidenziale */
+    protected $datiCassaPrevidenziale;
+
 
     /**
      * DatiGenerali constructor.
@@ -66,6 +73,16 @@ class DatiGenerali implements XmlSerializableInterface
         $this->datiContratto = $datiContratto;
     }
 
+    public function setDatiRitenuta(DatiRitenuta $datiRitenuta)
+    {
+        $this->datiRitenuta = $datiRitenuta;
+    }
+
+    public function setDatiCassaPrevidenziale(DatiCassaPrevidenziale $datiCassaPrevidenziale)
+    {
+        $this->datiCassaPrevidenziale = $datiCassaPrevidenziale;
+    }
+
     /**
      * @param \XMLWriter $writer
      * @return \XMLWriter
@@ -78,10 +95,13 @@ class DatiGenerali implements XmlSerializableInterface
                 $writer->writeElement('Divisa', $this->divisa);
                 $writer->writeElement('Data', $this->data);
                 $writer->writeElement('Numero', $this->numero);
-                $writer->writeElement(
-                    'ImportoTotaleDocumento',
-                    fe_number_format($this->importoTotaleDocumento, 2)
-                );
+                $writer->writeElement('ImportoTotaleDocumento',fe_number_format($this->importoTotaleDocumento, 2));
+		if ($this->datiRitenuta) {
+                        $this->datiRitenuta->toXmlBlock($writer);
+                }
+		if ($this->datiCassaPrevidenziale) {
+                        $this->datiCassaPrevidenziale->toXmlBlock($writer);
+                }
                 $this->writeXmlFields($writer);
             $writer->endElement();
             if ($this->datiContratto) {

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -15,6 +15,7 @@ use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGener
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiDdt;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiRitenuta;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiCassaPrevidenziale;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiSal;
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
@@ -39,6 +40,8 @@ class DatiGenerali implements XmlSerializableInterface
     protected $datiRitenuta;
     /** @var DatiCassaPrevidenziale */
     protected $datiCassaPrevidenziale;
+    /** @var DatiSal */
+    protected $datiSal;
 
 
     /**
@@ -83,6 +86,11 @@ class DatiGenerali implements XmlSerializableInterface
         $this->datiCassaPrevidenziale = $datiCassaPrevidenziale;
     }
 
+    public function setDatiSal(DatiSal $datiSal)
+    {
+        $this->datiSal = $datiSal;
+    }
+
     /**
      * @param \XMLWriter $writer
      * @return \XMLWriter
@@ -96,16 +104,19 @@ class DatiGenerali implements XmlSerializableInterface
                 $writer->writeElement('Data', $this->data);
                 $writer->writeElement('Numero', $this->numero);
                 $writer->writeElement('ImportoTotaleDocumento',fe_number_format($this->importoTotaleDocumento, 2));
-		if ($this->datiRitenuta) {
-                        $this->datiRitenuta->toXmlBlock($writer);
+                if ($this->datiRitenuta) {
+                    $this->datiRitenuta->toXmlBlock($writer);
                 }
-		if ($this->datiCassaPrevidenziale) {
-                        $this->datiCassaPrevidenziale->toXmlBlock($writer);
+                if ($this->datiCassaPrevidenziale) {
+                    $this->datiCassaPrevidenziale->toXmlBlock($writer);
                 }
                 $this->writeXmlFields($writer);
             $writer->endElement();
             if ($this->datiContratto) {
                 $this->datiContratto->toXmlBlock($writer);
+            }
+            if ($this->datiSal) {
+                $this->datiSal->toXmlBlock($writer);
             }
             if ($this->datiDdt) {
                 $this->datiDdt->toXmlBlock($writer);

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -11,6 +11,7 @@
 
 namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiContratto;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiDdt;
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
@@ -30,6 +31,8 @@ class DatiGenerali implements XmlSerializableInterface
     protected $divisa;
     /** @var DatiDdt */
     protected $datiDdt;
+    /** @var DatiContratto */
+    protected $datiContratto;
 
     /**
      * DatiGenerali constructor.
@@ -58,6 +61,11 @@ class DatiGenerali implements XmlSerializableInterface
         $this->datiDdt = $datiDdt;
     }
 
+    public function setDatiContratto(DatiContratto $datiContratto)
+    {
+        $this->datiContratto = $datiContratto;
+    }
+
     /**
      * @param \XMLWriter $writer
      * @return \XMLWriter
@@ -76,6 +84,9 @@ class DatiGenerali implements XmlSerializableInterface
                 );
                 $this->writeXmlFields($writer);
             $writer->endElement();
+            if ($this->datiContratto) {
+                $this->datiContratto->toXmlBlock($writer);
+            }
             if ($this->datiDdt) {
                 $this->datiDdt->toXmlBlock($writer);
             }

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -103,13 +103,13 @@ class DatiGenerali implements XmlSerializableInterface
                 $writer->writeElement('Divisa', $this->divisa);
                 $writer->writeElement('Data', $this->data);
                 $writer->writeElement('Numero', $this->numero);
-                $writer->writeElement('ImportoTotaleDocumento',fe_number_format($this->importoTotaleDocumento, 2));
                 if ($this->datiRitenuta) {
                     $this->datiRitenuta->toXmlBlock($writer);
                 }
                 if ($this->datiCassaPrevidenziale) {
                     $this->datiCassaPrevidenziale->toXmlBlock($writer);
                 }
+                $writer->writeElement('ImportoTotaleDocumento',fe_number_format($this->importoTotaleDocumento, 2));
                 $this->writeXmlFields($writer);
             $writer->endElement();
             if ($this->datiContratto) {

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -11,6 +11,7 @@
 
 namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiDdt;
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
@@ -27,6 +28,8 @@ class DatiGenerali implements XmlSerializableInterface
     protected $importoTotaleDocumento;
     /** @var string */
     protected $divisa;
+    /** @var DatiDdt */
+    protected $datiDdt;
 
     /**
      * DatiGenerali constructor.
@@ -50,6 +53,11 @@ class DatiGenerali implements XmlSerializableInterface
         $this->divisa = $divisa;
     }
 
+    public function setDatiDdt(DatiDdt $datiDdt)
+    {
+        $this->datiDdt = $datiDdt;
+    }
+
     /**
      * @param \XMLWriter $writer
      * @return \XMLWriter
@@ -66,6 +74,9 @@ class DatiGenerali implements XmlSerializableInterface
                     'ImportoTotaleDocumento',
                     fe_number_format($this->importoTotaleDocumento, 2)
                 );
+                if ($this->datiDdt) {
+                    $this->datiDdt->toXmlBlock($writer);
+                }
                 $this->writeXmlFields($writer);
             $writer->endElement();
         $writer->endElement();

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiCassaPrevidenziale.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiCassaPrevidenziale.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class DatiCassaPrevidenziale implements XmlSerializableInterface, \Countable, \Iterator
+{
+    use MagicFieldsTrait;
+
+/*
+<xs:complexType name="DatiCassaPrevidenzialeType">
+    <xs:sequence>
+      <xs:element name="TipoCassa"                  type="TipoCassaType"                    />
+      <xs:element name="AlCassa"                    type="RateType"                         />
+      <xs:element name="ImportoContributoCassa"     type="Amount2DecimalType"               />
+      <xs:element name="ImponibileCassa"            type="Amount2DecimalType" minOccurs="0" />
+      <xs:element name="AliquotaIVA"                type="RateType"                         />
+      <xs:element name="Ritenuta"                   type="RitenutaType"       minOccurs="0" />
+      <xs:element name="Natura"                     type="NaturaType"         minOccurs="0" />
+      <xs:element name="RiferimentoAmministrazione" type="String20Type"       minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+
+*/
+    /** @var string */
+    protected $tipo;
+    /** @var float */
+    protected $alCassa;
+    /** @var float */
+    protected $importoContributo;
+    /** @var float */
+    protected $imponibile;
+    /** @var float */
+    protected $aliquotaIVA;
+    /** @var ritenuta */
+    protected $ritenuta;
+    /** @var natura */
+    protected $natura;
+    /** @var string */
+    protected $riferimentoAmministrazione;
+/*
+*/
+    /**
+     * DatiCassaPrevidenziale constructor.
+     * @param string $numeroDdt
+     * @param string $dataDdt
+     * @param array $riferimentoNumeroLinee
+     */
+    public function __construct($tipo, $alCassa, $importo, $imponibile, $aliquotaIVA, $ritenuta, $natura, $riferimento)
+    {
+        $this->tipo = $tipo;
+        $this->alCassa = $alCassa;
+        $this->importoContributo = $importo;
+        $this->imponibile = $imponibile;
+        $this->aliquotaIVA = $aliquotaIVA;
+        $this->ritenuta = $ritenuta;
+        $this->natura = $natura;
+        $this->riferimentoAmministrazione = $riferimento;
+    }
+
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        $writer->startElement('DatiCassaPrevidenziale');
+                $writer->writeElement('TipoCassa', $this->tipo);
+                $writer->writeElement('AlCassa', $this->alCassa);
+                $writer->writeElement('ImportoContributoCassa', $this->importoContributo);
+                $writer->writeElement('ImponibileCassa', $this->imponibile);
+                $writer->writeElement('AliquotaIVA', $this->causale);
+		if ($this->ritenuta) {
+			$this->ritenuta->toXmlBlock($writer);
+		}
+		if ($this->natura) {
+			$this->natura->toXmlBlock($writer);
+		}
+                $writer->writeElement('RiferimentoAmministrazione', $this->riferimentoAmministrazione);
+        $writer->endElement();
+        return $writer;
+    }
+
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiCassaPrevidenziale.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiCassaPrevidenziale.php
@@ -14,7 +14,7 @@ namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Dat
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
-class DatiCassaPrevidenziale implements XmlSerializableInterface, \Countable, \Iterator
+class DatiCassaPrevidenziale implements XmlSerializableInterface
 {
     use MagicFieldsTrait;
 
@@ -78,17 +78,19 @@ class DatiCassaPrevidenziale implements XmlSerializableInterface, \Countable, \I
     {
         $writer->startElement('DatiCassaPrevidenziale');
                 $writer->writeElement('TipoCassa', $this->tipo);
-                $writer->writeElement('AlCassa', $this->alCassa);
-                $writer->writeElement('ImportoContributoCassa', $this->importoContributo);
-                $writer->writeElement('ImponibileCassa', $this->imponibile);
-                $writer->writeElement('AliquotaIVA', $this->causale);
+                $writer->writeElement('AlCassa', fe_number_format($this->alCassa,2));
+                $writer->writeElement('ImportoContributoCassa', fe_number_format($this->importoContributo,2));
+                $writer->writeElement('ImponibileCassa', fe_number_format($this->imponibile,2));
+                $writer->writeElement('AliquotaIVA', fe_number_format($this->aliquotaIVA,2));
 		if ($this->ritenuta) {
 			$this->ritenuta->toXmlBlock($writer);
 		}
 		if ($this->natura) {
 			$this->natura->toXmlBlock($writer);
 		}
-                $writer->writeElement('RiferimentoAmministrazione', $this->riferimentoAmministrazione);
+		if ($this->riferimentoAmministrazione) {
+			$writer->writeElement('RiferimentoAmministrazione', $this->riferimentoAmministrazione);
+		}
         $writer->endElement();
         return $writer;
     }

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiContratto.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiContratto.php
@@ -14,58 +14,30 @@ namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Dat
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
-class DatiDdt implements XmlSerializableInterface, \Countable, \Iterator
+class DatiContratto implements XmlSerializableInterface, \Countable, \Iterator
 {
+    const FE_CODE = '2.1.2';
     use MagicFieldsTrait;
-
-    /** @var DatiDdt[]  */
-    protected $datiDdt = [];
-    /** @var string */
-    protected $numeroDdt;
-    /** @var string */
-    protected $dataDdt;
-    /** @var int[] */
-    protected $riferimentoNumeroLinee = [];
-    /** @var int  */
+    protected $datiContratto = [];
     protected $currentIndex = 0;
+    protected $riferimentoNumeroLinee = [];
+    protected $idDocumento;
 
     /**
-     * DatiDdt constructor.
-     * @param string $numeroDdt
-     * @param string $dataDdt
-     * @param array $riferimentoNumeroLinee
+     * DatiContratto constructor.
+     * @param string $idDocumento
+     * @param int[] $riferimentoNumeroLinee
      */
-    public function __construct($numeroDdt, $dataDdt, $riferimentoNumeroLinee = [])
+    public function __construct($idDocumento, $riferimentoNumeroLinee = [])
     {
-        $this->numeroDdt = $numeroDdt;
-        $this->dataDdt = $dataDdt;
+        $this->idDocumento = $idDocumento;
         $this->riferimentoNumeroLinee = $riferimentoNumeroLinee;
-        $this->datiDdt[] = $this;
+        $this->datiContratto[] = $this;
     }
 
-
-    public function addDatiDdt(DatiDdt $datiDdt)
+    public function addDatiContratto(DatiContratto $datiContratto)
     {
-        $this->datiDdt[] = $datiDdt;
-    }
-
-    /**
-     * @param \XMLWriter $writer
-     * @return \XMLWriter
-     */
-    public function toXmlBlock(\XMLWriter $writer)
-    {
-        /** @var DatiDdt $block */
-        foreach ($this as $block) {
-            $writer->startElement('DatiDDT');
-                $writer->writeElement('NumeroDDT', $block->numeroDdt);
-                $writer->writeElement('DataDDT', $block->dataDdt);
-                foreach ($block->riferimentoNumeroLinee as $numeroLinea) {
-                    $writer->writeElement('RiferimentoNumeroLinea', $numeroLinea);
-                }
-            $writer->endElement();
-        }
-        return $writer;
+        $this->datiContratto[] = $datiContratto;
     }
 
     /**
@@ -76,7 +48,7 @@ class DatiDdt implements XmlSerializableInterface, \Countable, \Iterator
      */
     public function current()
     {
-        return $this->datiDdt[$this->currentIndex];
+        return $this->datiContratto[$this->currentIndex];
     }
 
     /**
@@ -110,7 +82,7 @@ class DatiDdt implements XmlSerializableInterface, \Countable, \Iterator
      */
     public function valid()
     {
-        return isset($this->datiDdt[$this->currentIndex]);
+        return isset($this->datiContratto[$this->currentIndex]);
     }
 
     /**
@@ -135,6 +107,27 @@ class DatiDdt implements XmlSerializableInterface, \Countable, \Iterator
      */
     public function count()
     {
-        return count($this->datiDdt);
+        return count($this->datiContratto);
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        /** @var DatiContratto $block */
+        foreach ($this as $block) {
+            $writer->startElement('DatiContratto');
+                if (count($block->riferimentoNumeroLinee) > 0) {
+                    /** @var int $linea */
+                    foreach ($block->riferimentoNumeroLinee as $linea) {
+                        $writer->writeElement('RiferimentoNumeroLinea', $linea);
+                    }
+                }
+                $writer->writeElement('IdDocumento', $block->idDocumento);
+                $block->writeXmlFields($writer);
+            $writer->endElement();
+        }
     }
 }

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiDdt.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiDdt.php
@@ -45,7 +45,7 @@ class DatiDdt implements XmlSerializableInterface, \Countable, \Iterator
 
     public function addDatiDdt(DatiDdt $datiDdt)
     {
-        $this->dataDdt[] = $datiDdt;
+        $this->datiDdt[] = $datiDdt;
     }
 
     /**

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiDdt.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiDdt.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class DatiDdt implements XmlSerializableInterface, \Countable, \Iterator
+{
+    use MagicFieldsTrait;
+
+    /** @var DatiDdt[]  */
+    protected $datiDdt = [];
+    /** @var string */
+    protected $numeroDdt;
+    /** @var string */
+    protected $dataDdt;
+    /** @var int[] */
+    protected $riferimentoNumeroLinee = [];
+    /** @var int  */
+    protected $currentIndex = 0;
+
+    /**
+     * DatiDdt constructor.
+     * @param string $numeroDdt
+     * @param string $dataDdt
+     * @param array $riferimentoNumeroLinee
+     */public function __construct($numeroDdt, $dataDdt, $riferimentoNumeroLinee = [])
+    {
+        $this->numeroDdt = $numeroDdt;
+        $this->dataDdt = $dataDdt;
+        $this->riferimentoNumeroLinee = $riferimentoNumeroLinee;
+        $this->datiDdt = [];
+    }
+
+
+    public function addDatiDdt(DatiDdt $datiDdt)
+    {
+        $this->dataDdt[] = $datiDdt;
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        /** @var DatiDdt $block */
+        foreach ($this as $block) {
+            $writer->startElement('DatiDDT');
+                $writer->writeElement('NumeroDDT', $block->numeroDdt);
+                $writer->writeElement('DataDDT', $block->dataDdt);
+                foreach ($block->riferimentoNumeroLinee as $numeroLinea) {
+                    $writer->writeElement('RiferimentoNumeroLinea', $numeroLinea);
+                }
+            $writer->endElement();
+        }
+        return $writer;
+    }
+
+    /**
+     * Return the current element
+     * @link https://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     * @since 5.0.0
+     */
+    public function current()
+    {
+        return $this->datiDdt[$this->currentIndex];
+    }
+
+    /**
+     * Move forward to next element
+     * @link https://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function next()
+    {
+        $this->currentIndex++;
+    }
+
+    /**
+     * Return the key of the current element
+     * @link https://php.net/manual/en/iterator.key.php
+     * @return mixed scalar on success, or null on failure.
+     * @since 5.0.0
+     */
+    public function key()
+    {
+        return $this->currentIndex;
+    }
+
+    /**
+     * Checks if current position is valid
+     * @link https://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     * @since 5.0.0
+     */
+    public function valid()
+    {
+        return isset($this->datiDdt[$this->currentIndex]);
+    }
+
+    /**
+     * Rewind the Iterator to the first element
+     * @link https://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function rewind()
+    {
+        $this->currentIndex = 0;
+    }
+
+    /**
+     * Count elements of an object
+     * @link https://php.net/manual/en/countable.count.php
+     * @return int The custom count as an integer.
+     * </p>
+     * <p>
+     * The return value is cast to an integer.
+     * @since 5.1.0
+     */
+    public function count()
+    {
+        return count($this->datiDdt);
+    }
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiRitenuta.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiRitenuta.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class DatiRitenuta implements XmlSerializableInterface, \Countable, \Iterator
+{
+    use MagicFieldsTrait;
+
+    /** @var DatiRitenuta  */
+    protected $datiRitenuta;
+    /** @var string */
+    protected $tipo;
+/*
+      <xs:length value="4" />
+      <xs:enumeration value="RT01">
+          <xs:documentation>Ritenuta di acconto persone fisiche</xs:documentation>
+      <xs:enumeration value="RT02">
+          <xs:documentation>Ritenuta di acconto persone giuridiche</xs:documentation>
+*/
+    /** @var float */
+    protected $importo;
+    /** @var float */
+    protected $aliquota;
+    /** @var string */
+    protected $causale;
+/*
+A	Prestazioni di lavoro autonomo rientranti nell’esercizio di arte o professione abituale.
+B	Utilizzazione economica, da parte dell’autore o dell’inventore, di opere dell’ingegno, di brevetti industriali e di processi, formule o informazioni relativi a esperienze acquisite in campo industriale, commerciale o scientifico.
+C	Utili derivanti da contratti di associazione in partecipazione e da contratti di cointeressenza, quando l’apporto è costituito esclusivamente dalla prestazione di lavoro.
+D	Utili spettanti ai soci promotori e ai soci fondatori delle società di capitali.
+E	Levata di protesti cambiari da parte dei segretari comunali.
+G	Indennità corrisposte per la cessazione di attività sportiva professionale.
+H	Indennità corrisposte per la cessazione dei rapporti di agenzia delle persone fisiche e delle società di persone, con esclusione delle somme maturate entro il 31.12.2003, già imputate per competenza e tassate come reddito d’impresa.
+I	Indennità corrisposte per la cessazione da funzioni notarili.
+L	Utilizzazione economica, da parte di soggetto diverso dall’autore o dall’inventore, di opere dell’ingegno, di brevetti industriali e di processi, formule e informazioni relative a esperienze acquisite in campo industriale, commerciale o scientifico.
+M	Prestazioni di lavoro autonomo non esercitate abitualmente, obblighi di fare, di non fare o permettere.
+N	Indennità di trasferta, rimborso forfetario di spese, premi e compensi erogati: .. nell’esercizio diretto di attività sportive dilettantistiche
+O	Prestazioni di lavoro autonomo non esercitate abitualmente, obblighi di fare, di non fare o permettere, per le quali non sussiste l’obbligo di iscrizione alla gestione separata (Circ. Inps 104/2001).
+P	Compensi corrisposti a soggetti non residenti privi di stabile organizzazione per l’uso o la concessione in uso di attrezzature industriali, commerciali o scientifiche che si trovano nel territorio dello
+Q	Provvigioni corrisposte ad agente o rappresentante di commercio monomandatario.
+R	Provvigioni corrisposte ad agente o rappresentante di commercio plurimandatario.
+S	Provvigioni corrisposte a commissionario.
+T	Provvigioni corrisposte a mediatore.
+U	Provvigioni corrisposte a procacciatore di affari.
+V	Provvigioni corrisposte a incaricato per le vendite a domicilio e provvigioni corrisposte a incaricato per la vendita porta a porta e per la vendita ambulante di giornali quotidiani e periodici (L. 25.02.1987, n. 67).
+W	Corrispettivi erogati nel 2013 per prestazioni relative a contratti d’appalto cui si sono resi applicabili le disposizioni contenute nell’art. 25-ter D.P.R. 600/1973.
+X	Canoni corrisposti nel 2004 da società o enti residenti, ovvero da stabili organizzazioni di società estere di cui all’art. 26-quater, c. 1, lett. a) e b) D.P.R. 600/1973, a società o stabili organizzazioni di società, situate in altro Stato membro dell’Unione Europea in presenza dei relativi requisiti richiesti, per i quali è stato effettuato nel 2006 il rimborso della ritenuta ai sensi dell’art. 4 D. Lgs. 143/2005.
+Y	Canoni corrisposti dal 1.01.2005 al 26.07.2005 da soggetti di cui al punto precedente.
+Z	Titolo diverso dai precedenti.
+*/
+    /**
+     * DatiRitenuta constructor.
+     * @param string $numeroDdt
+     * @param string $dataDdt
+     * @param array $riferimentoNumeroLinee
+     */
+    public function __construct($tipo, $importo, $aliquota, $causale)
+    {
+        $this->tipo = $tipo;
+        $this->importo = $importo;
+        $this->aliquota = $aliquota;
+        $this->causale = $causale;
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        $writer->startElement('DatiRitenuta');
+                $writer->writeElement('TipoRitenuta', $this->tipo);
+                $writer->writeElement('ImportoRitenuta', fe_number_format($this->importo,2));
+                $writer->writeElement('AliquotaRitenuta', fe_number_format($this->aliquota,2));
+                $writer->writeElement('CausalePagamento', $this->causale);
+        $writer->endElement();
+        return $writer;
+    }
+
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiRitenuta.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiRitenuta.php
@@ -14,7 +14,7 @@ namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Dat
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
 use Deved\FatturaElettronica\XmlSerializableInterface;
 
-class DatiRitenuta implements XmlSerializableInterface, \Countable, \Iterator
+class DatiRitenuta implements XmlSerializableInterface
 {
     use MagicFieldsTrait;
 
@@ -22,44 +22,13 @@ class DatiRitenuta implements XmlSerializableInterface, \Countable, \Iterator
     protected $datiRitenuta;
     /** @var string */
     protected $tipo;
-/*
-      <xs:length value="4" />
-      <xs:enumeration value="RT01">
-          <xs:documentation>Ritenuta di acconto persone fisiche</xs:documentation>
-      <xs:enumeration value="RT02">
-          <xs:documentation>Ritenuta di acconto persone giuridiche</xs:documentation>
-*/
     /** @var float */
     protected $importo;
     /** @var float */
     protected $aliquota;
     /** @var string */
     protected $causale;
-/*
-A	Prestazioni di lavoro autonomo rientranti nell’esercizio di arte o professione abituale.
-B	Utilizzazione economica, da parte dell’autore o dell’inventore, di opere dell’ingegno, di brevetti industriali e di processi, formule o informazioni relativi a esperienze acquisite in campo industriale, commerciale o scientifico.
-C	Utili derivanti da contratti di associazione in partecipazione e da contratti di cointeressenza, quando l’apporto è costituito esclusivamente dalla prestazione di lavoro.
-D	Utili spettanti ai soci promotori e ai soci fondatori delle società di capitali.
-E	Levata di protesti cambiari da parte dei segretari comunali.
-G	Indennità corrisposte per la cessazione di attività sportiva professionale.
-H	Indennità corrisposte per la cessazione dei rapporti di agenzia delle persone fisiche e delle società di persone, con esclusione delle somme maturate entro il 31.12.2003, già imputate per competenza e tassate come reddito d’impresa.
-I	Indennità corrisposte per la cessazione da funzioni notarili.
-L	Utilizzazione economica, da parte di soggetto diverso dall’autore o dall’inventore, di opere dell’ingegno, di brevetti industriali e di processi, formule e informazioni relative a esperienze acquisite in campo industriale, commerciale o scientifico.
-M	Prestazioni di lavoro autonomo non esercitate abitualmente, obblighi di fare, di non fare o permettere.
-N	Indennità di trasferta, rimborso forfetario di spese, premi e compensi erogati: .. nell’esercizio diretto di attività sportive dilettantistiche
-O	Prestazioni di lavoro autonomo non esercitate abitualmente, obblighi di fare, di non fare o permettere, per le quali non sussiste l’obbligo di iscrizione alla gestione separata (Circ. Inps 104/2001).
-P	Compensi corrisposti a soggetti non residenti privi di stabile organizzazione per l’uso o la concessione in uso di attrezzature industriali, commerciali o scientifiche che si trovano nel territorio dello
-Q	Provvigioni corrisposte ad agente o rappresentante di commercio monomandatario.
-R	Provvigioni corrisposte ad agente o rappresentante di commercio plurimandatario.
-S	Provvigioni corrisposte a commissionario.
-T	Provvigioni corrisposte a mediatore.
-U	Provvigioni corrisposte a procacciatore di affari.
-V	Provvigioni corrisposte a incaricato per le vendite a domicilio e provvigioni corrisposte a incaricato per la vendita porta a porta e per la vendita ambulante di giornali quotidiani e periodici (L. 25.02.1987, n. 67).
-W	Corrispettivi erogati nel 2013 per prestazioni relative a contratti d’appalto cui si sono resi applicabili le disposizioni contenute nell’art. 25-ter D.P.R. 600/1973.
-X	Canoni corrisposti nel 2004 da società o enti residenti, ovvero da stabili organizzazioni di società estere di cui all’art. 26-quater, c. 1, lett. a) e b) D.P.R. 600/1973, a società o stabili organizzazioni di società, situate in altro Stato membro dell’Unione Europea in presenza dei relativi requisiti richiesti, per i quali è stato effettuato nel 2006 il rimborso della ritenuta ai sensi dell’art. 4 D. Lgs. 143/2005.
-Y	Canoni corrisposti dal 1.01.2005 al 26.07.2005 da soggetti di cui al punto precedente.
-Z	Titolo diverso dai precedenti.
-*/
+
     /**
      * DatiRitenuta constructor.
      * @param string $numeroDdt

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiSal.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiSal.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class DatiSal implements XmlSerializableInterface, \Countable, \Iterator
+{
+    use MagicFieldsTrait;
+
+    /** @var DatiSal[]  */
+    protected $datiSal = [];
+    /** @var int[] */
+    protected $riferimentoFase = [];
+    /** @var int  */
+    protected $currentIndex = 0;
+
+    /**
+     * DatiSal constructor.
+     * @param int $riferimentoFase
+     */
+    public function __construct($riferimentoFase)
+    {
+        $this->riferimentoFase = $riferimentoFase;
+        $this->datiSal[] = $this;
+    }
+
+    public function addatiSal(DatiSal $datiSal)
+    {
+        $this->datiSal[] = $datiSal;
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        /** @var DatiSAL $block */
+        foreach ($this as $block) {
+            $writer->startElement('DatiSAL');
+            $writer->writeElement('RiferimentoFase', $block->riferimentoFase);
+            $writer->endElement();
+        }
+        return $writer;
+    }
+
+    /**
+     * Return the current element
+     * @link https://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     * @since 5.0.0
+     */
+    public function current()
+    {
+        return $this->datiSal[$this->currentIndex];
+    }
+
+    /**
+     * Move forward to next element
+     * @link https://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function next()
+    {
+        $this->currentIndex++;
+    }
+
+    /**
+     * Return the key of the current element
+     * @link https://php.net/manual/en/iterator.key.php
+     * @return mixed scalar on success, or null on failure.
+     * @since 5.0.0
+     */
+    public function key()
+    {
+        return $this->currentIndex;
+    }
+
+    /**
+     * Checks if current position is valid
+     * @link https://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     * @since 5.0.0
+     */
+    public function valid()
+    {
+        return isset($this->datiSal[$this->currentIndex]);
+    }
+
+    /**
+     * Rewind the Iterator to the first element
+     * @link https://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function rewind()
+    {
+        $this->currentIndex = 0;
+    }
+
+    /**
+     * Count elements of an object
+     * @link https://php.net/manual/en/countable.count.php
+     * @return int The custom count as an integer.
+     * </p>
+     * <p>
+     * The return value is cast to an integer.
+     * @since 5.1.0
+     */
+    public function count()
+    {
+        return count($this->datiSal);
+    }
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
@@ -61,7 +61,9 @@ class DatiPagamento extends XmlRepeatedBlock
             $writer->writeElement('CondizioniPagamento', $block->condizioniPagamento);
             $writer->startElement('DettaglioPagamento');
             $writer->writeElement('ModalitaPagamento', $block->modalitaPagamento);
-            $writer->writeElement('DataScadenzaPagamento', $block->dataScadenzaPagamento);
+            if ($block->dataScadenzaPagamento) {
+                $writer->writeElement('DataScadenzaPagamento', $block->dataScadenzaPagamento);
+            }
             $writer->writeElement('ImportoPagamento', fe_number_format($block->importoPagamento, 2));
             if ($block->istitutoFinanziario) {
                 $writer->writeElement('IstitutoFinanziario', $block->istitutoFinanziario);

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
@@ -16,8 +16,6 @@ use Deved\FatturaElettronica\XmlRepeatedBlock;
 
 class DatiPagamento extends XmlRepeatedBlock
 {
-    use MagicFieldsTrait;
-
     public $modalitaPagamento;
     public $dataScadenzaPagamento;
     public $importoPagamento;

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiPagamento.php
@@ -12,9 +12,9 @@
 namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
 
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
-use Deved\FatturaElettronica\XmlSerializableInterface;
+use Deved\FatturaElettronica\XmlRepeatedBlock;
 
-class DatiPagamento implements XmlSerializableInterface
+class DatiPagamento extends XmlRepeatedBlock
 {
     use MagicFieldsTrait;
 
@@ -48,6 +48,7 @@ class DatiPagamento implements XmlSerializableInterface
         $this->iban = $iban;
         $this->istitutoFinanziario = $istitutoFinanziario;
         $this->condizioniPagamento = $condizioniPagamento;
+        parent::__construct();
     }
 
     /**
@@ -56,22 +57,24 @@ class DatiPagamento implements XmlSerializableInterface
      */
     public function toXmlBlock(\XMLWriter $writer)
     {
-        $writer->startElement('DatiPagamento');
-        $writer->writeElement('CondizioniPagamento', $this->condizioniPagamento);
-        $writer->startElement('DettaglioPagamento');
-        $writer->writeElement('ModalitaPagamento', $this->modalitaPagamento);
-        $writer->writeElement('DataScadenzaPagamento', $this->dataScadenzaPagamento);
-        $writer->writeElement('ImportoPagamento', fe_number_format($this->importoPagamento, 2));
-        if ($this->istitutoFinanziario) {
-            $writer->writeElement('IstitutoFinanziario', $this->istitutoFinanziario);
+        /** @var DatiPagamento $block */
+        foreach ($this->blocks as $block) {
+            $writer->startElement('DatiPagamento');
+            $writer->writeElement('CondizioniPagamento', $block->condizioniPagamento);
+            $writer->startElement('DettaglioPagamento');
+            $writer->writeElement('ModalitaPagamento', $block->modalitaPagamento);
+            $writer->writeElement('DataScadenzaPagamento', $block->dataScadenzaPagamento);
+            $writer->writeElement('ImportoPagamento', fe_number_format($block->importoPagamento, 2));
+            if ($block->istitutoFinanziario) {
+                $writer->writeElement('IstitutoFinanziario', $block->istitutoFinanziario);
+            }
+            if ($block->iban) {
+                $writer->writeElement('IBAN', $block->iban);
+            }
+            $block->writeXmlFields($writer);
+            $writer->endElement();
+            $writer->endElement();
         }
-        if ($this->iban) {
-            $writer->writeElement('IBAN', $this->iban);
-        }
-        $this->writeXmlFields($writer);
-        $writer->endElement();
-        $writer->endElement();
-
         return $writer;
     }
 }

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiVeicoli.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiVeicoli.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class DatiVeicoli implements XmlSerializableInterface
+{
+    use MagicFieldsTrait;
+
+    /** @var string */
+    protected $data;
+    /** @var string */
+    protected $totalePercorso;
+
+    /**
+     * DatiVeicoli constructor.
+     * @param string $data
+     * @param string $totalePercorso
+     */
+    public function __construct($data, $totalePercorso)
+    {
+        $this->data = $data;
+        $this->totalePercorso = $totalePercorso;
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        $writer->startElement('DatiVeicoli');
+        $writer->writeElement('Data', $this->data);
+        $writer->writeElement('TotalePercorso', $this->totalePercorso);
+        $this->writeXmlFields($writer);
+        $writer->endElement();
+        return $writer;
+    }
+}

--- a/src/FatturaElettronica/FatturaElettronicaHeader.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Types\Nullable;
 
 class FatturaElettronicaHeader implements XmlSerializableInterface
 {
+    const FE_CODE = 1.0;
     /** @var DatiTrasmissione */
     public $datiTrasmissione;
     /** @var CedentePrestatore */

--- a/src/FatturaElettronica/FatturaElettronicaHeader.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader.php
@@ -24,7 +24,7 @@ class FatturaElettronicaHeader implements XmlSerializableInterface
     /** @var DatiTrasmissione */
     public $datiTrasmissione;
     /** @var CedentePrestatore */
-    protected $cedentePrestatore;
+    public $cedentePrestatore;
     /** @var CessionarioCommittente */
     protected $cessionarioCommittente;
     /** @var DatiAnagrafici|null */

--- a/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
@@ -11,6 +11,7 @@
 
 namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader;
 
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\DatiAnagrafici;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\Sede;
 use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
@@ -23,18 +24,24 @@ class CedentePrestatore implements XmlSerializableInterface
     protected $datiAnagrafici;
     /** @var Sede */
     protected $sede;
+    /** @var IscrizioneRea */
+    protected $iscrizioneRea;
+
 
     /**
      * CedentePrestatore constructor.
      * @param DatiAnagrafici $datiAnagrafici
      * @param Sede $sede
+     * @param IscrizioneRea $iscrizioneRea
      */
     public function __construct(
         DatiAnagrafici $datiAnagrafici,
-        Sede $sede
+        Sede $sede,
+        IscrizioneRea $iscrizioneRea = null
     ) {
         $this->datiAnagrafici = $datiAnagrafici;
         $this->sede = $sede;
+        $this->iscrizioneRea = $iscrizioneRea;
     }
 
     /**
@@ -46,6 +53,9 @@ class CedentePrestatore implements XmlSerializableInterface
         $writer->startElement('CedentePrestatore');
             $this->datiAnagrafici->toXmlBlock($writer);
             $this->sede->toXmlBlock($writer);
+            if ($this->iscrizioneRea) {
+                $this->iscrizioneRea->toXmlBlock($writer);
+            }
             $this->writeXmlFields($writer);
         $writer->endElement();
         return $writer;

--- a/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
@@ -45,6 +45,14 @@ class CedentePrestatore implements XmlSerializableInterface
     }
 
     /**
+     * @param IscrizioneRea $iscrizioneRea
+     */
+    public function setIscrizioneRea(IscrizioneRea $iscrizioneRea)
+    {
+        $this->iscrizioneRea = $iscrizioneRea;
+    }
+
+    /**
      * @param \XMLWriter $writer
      * @return \XMLWriter
      */

--- a/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore/IscrizioneRea.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore/IscrizioneRea.php
@@ -15,6 +15,11 @@ use Deved\FatturaElettronica\XmlSerializableInterface;
 
 class IscrizioneRea implements XmlSerializableInterface
 {
+    const SOCIO_UNICO = 'SU';
+    const SOCIETA_PLURIPERSONALE = 'SM';
+    const NON_IN_LIQUIDAZIONE = 'LN';
+    const IN_LIQUIDAZIONE = 'LS';
+
     /** @var string  */
     protected $ufficio;
     /** @var string  */

--- a/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore/IscrizioneRea.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore/IscrizioneRea.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore;
+
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class IscrizioneRea implements XmlSerializableInterface
+{
+    /** @var string  */
+    protected $ufficio;
+    /** @var string  */
+    protected $numeroRea;
+    /** @var float|null  */
+    protected $capitaleSociale;
+    /** @var string|null  */
+    protected $socioUnico;
+    /** @var string  */
+    protected $statoLiquidazione;
+
+    /**
+     * IscrizioneRea constructor.
+     * @param string $ufficio
+     * @param string $numeroRea
+     * @param null|float $capitaleSociale
+     * @param null|string $socioUnico
+     * @param string $statoLiquidazione
+     */
+    public function __construct($ufficio, $numeroRea, $capitaleSociale = null, $socioUnico = null, $statoLiquidazione = 'LN')
+    {
+        $this->ufficio = $ufficio;
+        $this->numeroRea = $numeroRea;
+        $this->capitaleSociale = $capitaleSociale;
+        $this->socioUnico = $socioUnico;
+        $this->statoLiquidazione = $statoLiquidazione;
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        $writer->startElement('IscrizioneREA');
+        $writer->writeElement('Ufficio', $this->ufficio);
+        $writer->writeElement('NumeroREA', $this->numeroRea);
+        if ($this->capitaleSociale) {
+            $writer->writeElement('CapitaleSociale', fe_number_format($this->capitaleSociale));
+        }
+        if ($this->socioUnico) {
+            $writer->writeElement('SocioUnico', $this->socioUnico);
+        }
+        $writer->writeElement('StatoLiquidazione', $this->statoLiquidazione);
+        $writer->endElement();
+
+        return $writer;
+    }
+}

--- a/src/FatturaElettronica/FatturaElettronicaHeader/Common/DatiAnagrafici.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/Common/DatiAnagrafici.php
@@ -28,6 +28,14 @@ class DatiAnagrafici implements XmlSerializableInterface
     /** @var string */
     public $regimeFiscale;
 
+    /**
+     * DatiAnagrafici constructor.
+     * @param string $codiceFiscale
+     * @param string $denominazione
+     * @param string $idPaese
+     * @param string $idCodice
+     * @param string $regimeFiscale
+     */
     public function __construct(
         $codiceFiscale,
         $denominazione,
@@ -55,7 +63,9 @@ class DatiAnagrafici implements XmlSerializableInterface
                 $writer->writeElement('IdCodice', $this->idCodice);
             $writer->endElement();
         }
+        if ($this->codiceFiscale) {
             $writer->writeElement('CodiceFiscale', $this->codiceFiscale);
+        }
             $writer->startElement('Anagrafica');
                 $writer->writeElement('Denominazione', $this->denominazione);
             $writer->endElement();

--- a/src/FatturaElettronica/FatturaElettronicaHeader/Common/DatiAnagrafici.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/Common/DatiAnagrafici.php
@@ -38,7 +38,7 @@ class DatiAnagrafici implements XmlSerializableInterface
      */
     public function __construct(
         $codiceFiscale,
-        $denominazione,
+        $denominazione = '',
         $idPaese = '',
         $idCodice = '',
         $regimeFiscale = ''
@@ -67,7 +67,11 @@ class DatiAnagrafici implements XmlSerializableInterface
             $writer->writeElement('CodiceFiscale', $this->codiceFiscale);
         }
             $writer->startElement('Anagrafica');
-                $writer->writeElement('Denominazione', $this->denominazione);
+                if ($this->denominazione) {
+                    $writer->writeElement('Denominazione', $this->denominazione);
+                }
+                $this->writeXmlField('Nome', $writer);
+                $this->writeXmlField('Cognome', $writer);
             $writer->endElement();
         if ($this->regimeFiscale) {
             $writer->writeElement('RegimeFiscale', $this->regimeFiscale);

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -12,6 +12,8 @@
 namespace Deved\FatturaElettronica;
 
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Allegato;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\DatiRiepilogo;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\DettaglioLinee;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
@@ -153,7 +155,8 @@ class FatturaElettronicaFactory
      * @param DatiPagamento $datiPagamento
      * @param DettaglioLinee $linee
      * @param bool $progessivoInvio
-     * @param FatturaElettronicaBody\DatiBeniServizi\DatiRiepilogo|null $datiRiepilogo
+     * @param DatiRiepilogo|null $datiRiepilogo
+     * @param Allegato|null $allegato
      * @return FatturaElettronica
      * @throws \Exception
      */
@@ -162,7 +165,8 @@ class FatturaElettronicaFactory
         DatiPagamento $datiPagamento = null,
         DettaglioLinee $linee,
         $progessivoInvio = false,
-        FatturaElettronicaBody\DatiBeniServizi\DatiRiepilogo $datiRiepilogo = null
+        DatiRiepilogo $datiRiepilogo = null,
+        Allegato $allegato = null
     ) {
         if (!$this->cessionarioCommittente) {
             throw new \Exception('Dati cessionario non presenti!');
@@ -192,7 +196,8 @@ class FatturaElettronicaFactory
         $fatturaElettronicaBody = new FatturaElettronicaBody(
             $datiGenerali,
             $datiBeniServizi,
-            $datiPagamento
+            $datiPagamento,
+            $allegato
         );
         return new FatturaElettronica($fatturaElettronicaHeader, $fatturaElettronicaBody, $this->xmlFactory);
     }

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -17,6 +17,7 @@ use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniS
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\DettaglioLinee;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiVeicoli;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CessionarioCommittente;
@@ -99,7 +100,7 @@ class FatturaElettronicaFactory
     }
 
     /**
-     * @param DatiTrasmissione\IdTrasmittente $idTrasmittente
+     * @param IdTrasmittente $idTrasmittente
      */
     public function setIdTrasmittente(IdTrasmittente $idTrasmittente)
     {
@@ -157,6 +158,7 @@ class FatturaElettronicaFactory
      * @param bool $progessivoInvio
      * @param DatiRiepilogo|null $datiRiepilogo
      * @param Allegato|null $allegato
+     * @param DatiVeicoli|null $datiVeicoli
      * @return FatturaElettronica
      * @throws \Exception
      */
@@ -166,7 +168,8 @@ class FatturaElettronicaFactory
         DettaglioLinee $linee,
         $progessivoInvio = false,
         DatiRiepilogo $datiRiepilogo = null,
-        Allegato $allegato = null
+        Allegato $allegato = null,
+        DatiVeicoli $datiVeicoli = null
     ) {
         if (!$this->cessionarioCommittente) {
             throw new \Exception('Dati cessionario non presenti!');
@@ -197,7 +200,8 @@ class FatturaElettronicaFactory
             $datiGenerali,
             $datiBeniServizi,
             $datiPagamento,
-            $allegato
+            $allegato,
+            $datiVeicoli
         );
         return new FatturaElettronica($fatturaElettronicaHeader, $fatturaElettronicaBody, $this->xmlFactory);
     }

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -97,6 +97,14 @@ class FatturaElettronicaFactory
     }
 
     /**
+     * @param DatiTrasmissione\IdTrasmittente $idTrasmittente
+     */
+    public function setIdTrasmittente(IdTrasmittente $idTrasmittente)
+    {
+        $this->idTrasmittente = $idTrasmittente;
+    }
+    
+    /**
      * @param DatiAnagrafici $terzoIntermediario
      * @param string $soggettoEmittente
      */

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -144,6 +144,8 @@ class FatturaElettronicaFactory
         $this->cessionarioCommittente = new CessionarioCommittente($datiAnagrafici, $sede);
         if ($codiceDestinatario) {
             $this->codiceDestinatario = $codiceDestinatario;
+        } else if ($datiAnagrafici->idPaese != 'IT') {
+        	$this->codiceDestinatario = 'XXXXXXX';
         }
         if ($pec) {
             $this->pec = $pec;

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -88,6 +88,18 @@ class FatturaElettronicaFactory
         }
     }
 
+    /**
+     * @param CedentePrestatore\IscrizioneRea $iscrizioneRea
+     */
+    public function setIscrizioneRea(CedentePrestatore\IscrizioneRea $iscrizioneRea)
+    {
+        $this->cedentePrestatore->setIscrizioneRea($iscrizioneRea);
+    }
+
+    /**
+     * @param DatiAnagrafici $terzoIntermediario
+     * @param string $soggettoEmittente
+     */
     public function setIntermediario(DatiAnagrafici $terzoIntermediario, $soggettoEmittente = 'TZ')
     {
         $this->terzoIntermediario = $terzoIntermediario;
@@ -104,6 +116,13 @@ class FatturaElettronicaFactory
         $this->email = $email;
     }
 
+    /**
+     * @param DatiAnagrafici $datiAnagrafici
+     * @param Sede $sede
+     * @param string $codiceDestinatario
+     * @param string $pec
+     * @param bool $pa
+     */
     public function setCessionarioCommittente(
         DatiAnagrafici $datiAnagrafici,
         Sede $sede,

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -151,7 +151,7 @@ class FatturaElettronicaFactory
      */
     public function create(
         DatiGenerali $datiGenerali,
-        DatiPagamento $datiPagamento,
+        DatiPagamento $datiPagamento = null,
         DettaglioLinee $linee,
         $progessivoInvio = false,
         FatturaElettronicaBody\DatiBeniServizi\DatiRiepilogo $datiRiepilogo = null

--- a/src/FatturaElettronicaInterface.php
+++ b/src/FatturaElettronicaInterface.php
@@ -35,4 +35,11 @@ interface FatturaElettronicaInterface
      * @return mixed
      */
     public function setIscrizioneRea(IscrizioneRea $iscrizioneRea);
+
+    /**
+     * Verifica l'xml della fattura
+     * @return bool
+     * @throws \Exception
+     */
+    public function verifica();
 }

--- a/src/FatturaElettronicaInterface.php
+++ b/src/FatturaElettronicaInterface.php
@@ -13,6 +13,8 @@
 namespace Deved\FatturaElettronica;
 
 
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea;
+
 interface FatturaElettronicaInterface
 {
     /**
@@ -27,4 +29,10 @@ interface FatturaElettronicaInterface
      * @throws \Exception
      */
     public function toXml();
+
+    /**
+     * @param IscrizioneRea $iscrizioneRea
+     * @return mixed
+     */
+    public function setIscrizioneRea(IscrizioneRea $iscrizioneRea);
 }

--- a/src/Traits/CodificaTrait.php
+++ b/src/Traits/CodificaTrait.php
@@ -30,4 +30,13 @@ trait CodificaTrait
         }
         return $descrizione;
     }
+    /**
+     * Lista della codifica
+     *
+     * @return array
+     */
+    public static function lista()
+    {
+         return self::$codifiche;
+    }
 }

--- a/src/Traits/MagicFieldsTrait.php
+++ b/src/Traits/MagicFieldsTrait.php
@@ -35,7 +35,7 @@ trait MagicFieldsTrait
      */
     protected function writeXmlField($field, \XMLWriter $writer)
     {
-        if ($this->{$field}) {
+        if ($this->{$field} !== false) {
             $writer->writeElement(ucfirst($field), $this->{$field});
             $this->deleteXmlField($field);
         }
@@ -48,7 +48,7 @@ trait MagicFieldsTrait
      */
     protected function deleteXmlField($field)
     {
-        if ($this->{$field}) {
+        if ($this->{$field} !== false) {
             unset($this->xmlFields[$field]);
         }
     }

--- a/src/Traits/MagicFieldsTrait.php
+++ b/src/Traits/MagicFieldsTrait.php
@@ -15,6 +15,7 @@ namespace Deved\FatturaElettronica\Traits;
 trait MagicFieldsTrait
 {
     protected $xmlFields = [];
+    protected $hiddenXmlFields = [];
 
     public function __set($name, $value)
     {
@@ -37,19 +38,19 @@ trait MagicFieldsTrait
     {
         if ($this->{$field} !== false) {
             $writer->writeElement(ucfirst($field), $this->{$field});
-            $this->deleteXmlField($field);
+            $this->hideXmlField($field);
         }
     }
 
     /**
-     * Delete xmlField
+     * Tag xmlField
      *
      * @param $field
      */
-    protected function deleteXmlField($field)
+    protected function hideXmlField($field)
     {
-        if ($this->{$field} !== false) {
-            unset($this->xmlFields[$field]);
+        if (!in_array($field, $this->hiddenXmlFields)) {
+            $this->hiddenXmlFields[] = $field;
         }
     }
 
@@ -59,7 +60,9 @@ trait MagicFieldsTrait
     protected function writeXmlFields(\XMLWriter $writer)
     {
         foreach ($this->xmlFields as $key => $value) {
-            $writer->writeElement(ucfirst($key), $value);
+            if (!in_array($key, $this->hiddenXmlFields)) {
+                $writer->writeElement(ucfirst($key), $value);
+            }
         }
     }
 }

--- a/src/XmlBlock.php
+++ b/src/XmlBlock.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+
+abstract class XmlBlock implements XmlSerializableInterface
+{
+    use MagicFieldsTrait;
+}

--- a/src/XmlRepeatedBlock.php
+++ b/src/XmlRepeatedBlock.php
@@ -21,7 +21,7 @@ abstract class XmlRepeatedBlock extends XmlBlock implements \Countable, \Iterato
         $this->blocks[] = $this;
     }
 
-    public function addBlock(self $block)
+    public function addBlock(XmlBlock $block)
     {
         $this->blocks[] = $block;
     }

--- a/src/XmlRepeatedBlock.php
+++ b/src/XmlRepeatedBlock.php
@@ -9,35 +9,21 @@
  *
  */
 
-namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+namespace Deved\FatturaElettronica;
 
-use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
-use Deved\FatturaElettronica\XmlSerializableInterface;
-
-class DatiContratto implements XmlSerializableInterface, \Countable, \Iterator
+abstract class XmlRepeatedBlock extends XmlBlock implements \Countable, \Iterator
 {
-    const FE_CODE = '2.1.2';
-    use MagicFieldsTrait;
-    protected $datiContratto = [];
+    protected $blocks = [];
     protected $currentIndex = 0;
-    protected $riferimentoNumeroLinee = [];
-    protected $idDocumento;
 
-    /**
-     * DatiContratto constructor.
-     * @param string $idDocumento
-     * @param int[] $riferimentoNumeroLinee
-     */
-    public function __construct($idDocumento, $riferimentoNumeroLinee = [])
+    public function __construct()
     {
-        $this->idDocumento = $idDocumento;
-        $this->riferimentoNumeroLinee = $riferimentoNumeroLinee;
-        $this->datiContratto[] = $this;
+        $this->blocks[] = $this;
     }
 
-    public function addDatiContratto(DatiContratto $datiContratto)
+    public function addBlock(self $block)
     {
-        $this->datiContratto[] = $datiContratto;
+        $this->blocks[] = $block;
     }
 
     /**
@@ -48,7 +34,7 @@ class DatiContratto implements XmlSerializableInterface, \Countable, \Iterator
      */
     public function current()
     {
-        return $this->datiContratto[$this->currentIndex];
+        return $this->blocks[$this->currentIndex];
     }
 
     /**
@@ -82,7 +68,7 @@ class DatiContratto implements XmlSerializableInterface, \Countable, \Iterator
      */
     public function valid()
     {
-        return isset($this->datiContratto[$this->currentIndex]);
+        return isset($this->blocks[$this->currentIndex]);
     }
 
     /**
@@ -107,28 +93,6 @@ class DatiContratto implements XmlSerializableInterface, \Countable, \Iterator
      */
     public function count()
     {
-        return count($this->datiContratto);
-    }
-
-    /**
-     * @param \XMLWriter $writer
-     * @return \XMLWriter
-     */
-    public function toXmlBlock(\XMLWriter $writer)
-    {
-        /** @var DatiContratto $block */
-        foreach ($this as $block) {
-            $writer->startElement('DatiContratto');
-                if (count($block->riferimentoNumeroLinee) > 0) {
-                    /** @var int $linea */
-                    foreach ($block->riferimentoNumeroLinee as $linea) {
-                        $writer->writeElement('RiferimentoNumeroLinea', $linea);
-                    }
-                }
-                $writer->writeElement('IdDocumento', $block->idDocumento);
-                $block->writeXmlFields($writer);
-            $writer->endElement();
-        }
-        return $writer;
+        return count($this->blocks);
     }
 }

--- a/tests/FatturaAliquoteMultipleTest.php
+++ b/tests/FatturaAliquoteMultipleTest.php
@@ -150,6 +150,8 @@ class FatturaAliquoteMultipleTest extends TestCase
         //linea con aliquota 0 e natura
         $lineaEsente = new Linea('Articolo non imponibile', 10, 'XYZ', 1, 'pz', '0');
         $lineaEsente->natura = Natura::Esenti;
+        $lineaEsente->DataInizioPeriodo = '2018-05-01';
+        $lineaEsente->DataFinePeriodo = '2018-05-31';
         $linee[] = $lineaEsente;
         $this->assertCount(3, $linee);
         return $linee;

--- a/tests/FatturaAllegatiTest.php
+++ b/tests/FatturaAllegatiTest.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\Tests;
+
+use Deved\FatturaElettronica\Codifiche\ModalitaPagamento;
+use Deved\FatturaElettronica\Codifiche\RegimeFiscale;
+use Deved\FatturaElettronica\Codifiche\TipoDocumento;
+use Deved\FatturaElettronica\FatturaElettronica;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\Allegato;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\DettaglioLinee;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\Linea;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\DatiAnagrafici;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\Sede;
+use Deved\FatturaElettronica\FatturaElettronicaFactory;
+use Deved\FatturaElettronica\XmlValidator;
+use PHPUnit\Framework\TestCase;
+
+class FatturaAllegatiTest extends TestCase
+{
+    /**
+     * @return DatiAnagrafici
+     */
+    public function testCreateAnagraficaCedente()
+    {
+        $anagraficaCedente = new DatiAnagrafici(
+            '12345678901',
+            'Acme SpA',
+            'IT',
+            '12345678901',
+            RegimeFiscale::Ordinario
+        );
+        $this->assertInstanceOf(DatiAnagrafici::class, $anagraficaCedente);
+        return $anagraficaCedente;
+    }
+
+    /**
+     * @return Sede
+     */
+    public function testCreateSedeCedente()
+    {
+        $sedeCedente = new Sede('IT', 'Via Roma 10', '33018', 'Tarvisio', 'UD');
+        $this->assertInstanceOf(Sede::class, $sedeCedente);
+        return $sedeCedente;
+    }
+
+    /**
+     * @depends testCreateAnagraficaCedente
+     * @depends testCreateSedeCedente
+     * @param DatiAnagrafici $datiAnagrafici
+     * @param Sede $sede
+     * @return FatturaElettronicaFactory
+     */
+    public function testCreateFatturaElettronicaFactory(DatiAnagrafici $datiAnagrafici, Sede $sede)
+    {
+        $feFactory = new FatturaElettronicaFactory(
+            $datiAnagrafici,
+            $sede,
+            '+39123456789',
+            'info@deved.it'
+        );
+        $this->assertInstanceOf(FatturaElettronicaFactory::class, $feFactory);
+        return $feFactory;
+    }
+
+    /**
+     * @return DatiAnagrafici
+     */
+    public function testCreateAnagraficaCessionario()
+    {
+        $anaCessionario = new DatiAnagrafici('XYZYZX77M04H888K', 'Pinco Palla');
+        $this->assertInstanceOf(DatiAnagrafici::class, $anaCessionario);
+        return $anaCessionario;
+    }
+
+    /**
+     * @return Sede
+     */
+    public function testCreateSedeCessionario()
+    {
+        $sedeCessionario = new Sede('IT', 'Via Diaz 35', '33018', 'Tarvisio', 'UD');
+        $this->assertInstanceOf(Sede::class, $sedeCessionario);
+        return$sedeCessionario;
+    }
+
+    /**
+     * @depends testCreateFatturaElettronicaFactory
+     * @depends testCreateAnagraficaCessionario
+     * @depends testCreateSedeCessionario
+     * @param FatturaElettronicaFactory $factory
+     * @param DatiAnagrafici $datiAnagrafici
+     * @param Sede $sede
+     * @return FatturaElettronicaFactory
+     */
+    public function testSetCessionarioCommittente(
+        FatturaElettronicaFactory $factory,
+        DatiAnagrafici $datiAnagrafici,
+        Sede $sede
+    ) {
+        $factory->setCessionarioCommittente($datiAnagrafici, $sede);
+        $this->assertInstanceOf(FatturaElettronicaFactory::class, $factory);
+        return $factory;
+    }
+
+    /**
+     * @return DatiGenerali\DatiDdt
+     */
+    public function testDatiDdt()
+    {
+        $datiDdt = new DatiGenerali\DatiDdt('A1', '2018-11-10', ['1', '2']);
+        $datiDdt->addDatiDdt(new DatiGenerali\DatiDdt('A2', '2018-12-09', ['3', '4']));
+        $this->assertInstanceOf(DatiGenerali\DatiDdt::class, $datiDdt);
+        return $datiDdt;
+    }
+
+    /**
+     * @depends testDatiDdt
+     * @param DatiGenerali\DatiDdt $datiDdt
+     * @return DatiGenerali
+     */
+    public function testCreateDatiGenerali(DatiGenerali\DatiDdt $datiDdt)
+    {
+        $datiGenerali = new DatiGenerali(
+            TipoDocumento::Fattura,
+            '2018-11-22',
+            '2018221111',
+            122
+        );
+        $datiGenerali->setDatiDdt($datiDdt);
+        $datiGenerali->Causale = "Fattura di prova";
+        $this->assertInstanceOf(DatiGenerali::class, $datiGenerali);
+        return $datiGenerali;
+    }
+
+    /**
+     * @return DatiPagamento
+     */
+    public function testCreateDatiPagamento()
+    {
+        $datiPagamento = new DatiPagamento(
+            ModalitaPagamento::SEPA_CORE,
+            '2018-11-30',
+            122
+        );
+        $this->assertInstanceOf(DatiPagamento::class, $datiPagamento);
+        return $datiPagamento;
+    }
+
+    /**
+     * @return array
+     */
+    public function testCreateLinee()
+    {
+        $linee = [];
+        $linee[] = new Linea('Articolo1', 50, 'ABC');
+        $linee[]= new Linea('Articolo2', 25, 'CDE', 2);
+        $this->assertCount(2, $linee);
+        return $linee;
+    }
+
+    /**
+     * @param array $linee
+     * @depends testCreateLinee
+     * @return DettaglioLinee
+     */
+    public function testCreateDettaglioLinee($linee)
+    {
+        $dettaglioLinee = new DettaglioLinee($linee);
+        $this->assertInstanceOf(DettaglioLinee::class, $dettaglioLinee);
+        return $dettaglioLinee;
+    }
+
+    /**
+     * @return Allegato
+     */
+    public function testCreateAllegato()
+    {
+        $allegato = new Allegato(
+            'fattura.pdf',
+            'fattura.pdf',
+            'pdf'
+        );
+        $this->assertInstanceOf(Allegato::class, $allegato);
+        return $allegato;
+    }
+
+    /**
+     * @depends testSetCessionarioCommittente
+     * @depends testCreateDatiGenerali
+     * @depends testCreateDatiPagamento
+     * @depends testCreateDettaglioLinee
+     * @depends testCreateAllegato
+     * @param FatturaElettronicaFactory $factory
+     * @param DatiGenerali $datiGenerali
+     * @param DatiPagamento $datiPagamento
+     * @param DettaglioLinee $dettaglioLinee
+     * @return \Deved\FatturaElettronica\FatturaElettronica
+     * @throws \Exception
+     */
+    public function testCreateFattura(
+        FatturaElettronicaFactory $factory,
+        DatiGenerali $datiGenerali,
+        DatiPagamento $datiPagamento,
+        DettaglioLinee $dettaglioLinee,
+        Allegato $allegato
+    ) {
+        $fattura = $factory->create($datiGenerali, $datiPagamento, $dettaglioLinee, '12345', null, $allegato);
+        $this->assertInstanceOf(FatturaElettronica::class, $fattura);
+        return $fattura;
+    }
+
+    /**
+     * @depends testCreateFattura
+     * @param FatturaElettronica $fattura
+     */
+    public function testGetNomeFattura(FatturaElettronica $fattura)
+    {
+        $name = $fattura->getFileName();
+        $this->assertTrue(strlen($name) > 5);
+    }
+
+
+    /**
+     * @depends testCreateFattura
+     * @param FatturaElettronica $fattura
+     * @throws \Exception
+     */
+    public function testXmlSchemaFattura(FatturaElettronica $fattura)
+    {
+        $this->assertTrue($fattura->verifica());
+    }
+}

--- a/tests/FatturaElettronicaAbiCab.php
+++ b/tests/FatturaElettronicaAbiCab.php
@@ -130,12 +130,24 @@ class FatturaElettronicaAbiCab extends TestCase
     public function testCreateDatiPagamento()
     {
         $datiPagamento = new DatiPagamento(
-            ModalitaPagamento::SEPA_CORE,
+            ModalitaPagamento::Contanti,
             '2018-11-30',
-            122
+            60,
+            null,
+            null,
+            'TP01'
         );
         $datiPagamento->ABI = '12345';
         $datiPagamento->CAB = '56789';
+        $datiPagamento->addBlock(new DatiPagamento(
+            ModalitaPagamento::Contanti,
+            '2018-12-31',
+                62,
+                null,
+                null,
+                'TP01'
+            )
+        );
         $this->assertInstanceOf(DatiPagamento::class, $datiPagamento);
         return $datiPagamento;
     }
@@ -204,6 +216,7 @@ class FatturaElettronicaAbiCab extends TestCase
      */
     public function testXmlSchemaFattura(FatturaElettronica $fattura)
     {
+        echo $fattura->toXml();
         $this->assertTrue($fattura->verifica());
     }
 }

--- a/tests/FatturaElettronicaAbiCab.php
+++ b/tests/FatturaElettronicaAbiCab.php
@@ -216,7 +216,7 @@ class FatturaElettronicaAbiCab extends TestCase
      */
     public function testXmlSchemaFattura(FatturaElettronica $fattura)
     {
-        echo $fattura->toXml();
+        //echo $fattura->toXml();
         $this->assertTrue($fattura->verifica());
     }
 }

--- a/tests/FatturaIntermediarioTest.php
+++ b/tests/FatturaIntermediarioTest.php
@@ -53,6 +53,16 @@ class FatturaIntermediarioTest extends TestCase
         return $sedeCedente;
     }
 
+    public function testCreateIscrizioneRea()
+    {
+        $iscrizioneRea = new FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea(
+            'UD',
+            '286546'
+        );
+        $this->assertInstanceOf(FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea::class, $iscrizioneRea);
+        return $iscrizioneRea;
+    }
+
     /**
      * @depends testCreateAnagraficaCedente
      * @depends testCreateSedeCedente

--- a/tests/FatturaIntermediarioTest.php
+++ b/tests/FatturaIntermediarioTest.php
@@ -149,6 +149,8 @@ class FatturaIntermediarioTest extends TestCase
         $linee = [];
         $linee[] = new Linea('Articolo1', 50, 'ABC');
         $linee[]= new Linea('Articolo2', 50, 'CDE');
+        $linee[0]->DataInizioPeriodo = '2018-10-01';
+        $linee[0]->DataFinePeriodo = '2018-10-31';
         $this->assertCount(2, $linee);
         return $linee;
     }

--- a/tests/FatturaIntermediarioTest.php
+++ b/tests/FatturaIntermediarioTest.php
@@ -53,6 +53,9 @@ class FatturaIntermediarioTest extends TestCase
         return $sedeCedente;
     }
 
+    /**
+     * @return FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea
+     */
     public function testCreateIscrizioneRea()
     {
         $iscrizioneRea = new FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea(
@@ -123,6 +126,23 @@ class FatturaIntermediarioTest extends TestCase
     }
 
     /**
+     * @depends testSetCessionarioCommittente
+     * @depends testCreateIscrizioneRea
+     * @param FatturaElettronicaFactory $factory
+     * @param FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea $iscrizioneRea
+     * @return FatturaElettronicaFactory
+     */
+    public function testSetIscrizioneRea(
+        FatturaElettronicaFactory $factory,
+        FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea $iscrizioneRea
+    )
+    {
+        $factory->setIscrizioneRea($iscrizioneRea);
+        $this->assertInstanceOf(FatturaElettronicaFactory::class, $factory);
+        return $factory;
+    }
+
+    /**
      * @return DatiGenerali
      */
     public function testCreateDatiGenerali()
@@ -178,7 +198,7 @@ class FatturaIntermediarioTest extends TestCase
     }
 
     /**
-     * @depends testSetCessionarioCommittente
+     * @depends testSetIscrizioneRea
      * @depends testCreateDatiGenerali
      * @depends testCreateDatiPagamento
      * @depends testCreateDettaglioLinee

--- a/tests/FatturaIntermediarioTest.php
+++ b/tests/FatturaIntermediarioTest.php
@@ -54,6 +54,20 @@ class FatturaIntermediarioTest extends TestCase
     }
 
     /**
+     * @return DatiGenerali\DatiContratto
+     */
+    public function testCreateDatiContratto()
+    {
+        $datiContratto = new DatiGenerali\DatiContratto('123', [1, 2]);
+        $datiContratto->Data = '2018-12-01';
+        $datiContratto->CodiceCIG = 'ABCDEF';
+        $datiContratto->addDatiContratto(new DatiGenerali\DatiContratto('234', [3,4]));
+        $datiContratto->addDatiContratto(new DatiGenerali\DatiContratto('567'));
+        $this->assertInstanceOf(DatiGenerali\DatiContratto::class, $datiContratto);
+        return $datiContratto;
+    }
+
+    /**
      * @return FatturaElettronica\FatturaElettronicaHeader\CedentePrestatore\IscrizioneRea
      */
     public function testCreateIscrizioneRea()
@@ -143,9 +157,10 @@ class FatturaIntermediarioTest extends TestCase
     }
 
     /**
+     * @depends testCreateDatiContratto
      * @return DatiGenerali
      */
-    public function testCreateDatiGenerali()
+    public function testCreateDatiGenerali(DatiGenerali\DatiContratto $datiContratto)
     {
         $datiGenerali = new DatiGenerali(
             TipoDocumento::Fattura,
@@ -153,6 +168,7 @@ class FatturaIntermediarioTest extends TestCase
             '2018221111',
             122
         );
+        $datiGenerali->setDatiContratto($datiContratto);
         $this->assertInstanceOf(DatiGenerali::class, $datiGenerali);
         return $datiGenerali;
     }
@@ -237,6 +253,7 @@ class FatturaIntermediarioTest extends TestCase
      */
     public function testXmlSchemaFattura(FatturaElettronica $fattura)
     {
+        //echo $fattura->toXml();
         $this->assertTrue($fattura->verifica());
     }
 }

--- a/tests/FatturaIntermediarioTest.php
+++ b/tests/FatturaIntermediarioTest.php
@@ -105,7 +105,9 @@ class FatturaIntermediarioTest extends TestCase
      */
     public function testCreateAnagraficaCessionario()
     {
-        $anaCessionario = new DatiAnagrafici('XYZYZX77M04H888K', 'Pinco Palla');
+        $anaCessionario = new DatiAnagrafici('XYZYZX77M04H888K');
+        $anaCessionario->Nome = 'Pinco';
+        $anaCessionario->Cognome = 'Pallino';
         $this->assertInstanceOf(DatiAnagrafici::class, $anaCessionario);
         return $anaCessionario;
     }

--- a/tests/FatturaSempliceTest.php
+++ b/tests/FatturaSempliceTest.php
@@ -111,16 +111,23 @@ class FatturaSempliceTest extends TestCase
         return $factory;
     }
 
+    /**
+     * @return DatiGenerali\DatiDdt
+     */
     public function testDatiDdt()
     {
         $datiDdt = new DatiGenerali\DatiDdt('A1', '2018-11-10', ['1', '2']);
-        $datiDdt->addDatiDdt(new DatiGenerali\DatiDdt('A2', '2018-12-9', ['3', '4']));
+        $datiDdt->addDatiDdt(new DatiGenerali\DatiDdt('A2', '2018-12-09', ['3', '4']));
+        $this->assertInstanceOf(DatiGenerali\DatiDdt::class, $datiDdt);
+        return $datiDdt;
     }
 
     /**
+     * @depends testDatiDdt
+     * @param DatiGenerali\DatiDdt $datiDdt
      * @return DatiGenerali
      */
-    public function testCreateDatiGenerali()
+    public function testCreateDatiGenerali(DatiGenerali\DatiDdt $datiDdt)
     {
         $datiGenerali = new DatiGenerali(
             TipoDocumento::Fattura,
@@ -128,6 +135,7 @@ class FatturaSempliceTest extends TestCase
             '2018221111',
             122
         );
+        $datiGenerali->setDatiDdt($datiDdt);
         $this->assertInstanceOf(DatiGenerali::class, $datiGenerali);
         return $datiGenerali;
     }

--- a/tests/FatturaSempliceTest.php
+++ b/tests/FatturaSempliceTest.php
@@ -19,6 +19,7 @@ use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniS
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\Linea;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiVeicoli;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\DatiAnagrafici;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\Sede;
 use Deved\FatturaElettronica\FatturaElettronicaFactory;
@@ -123,11 +124,22 @@ class FatturaSempliceTest extends TestCase
     }
 
     /**
+     * @return DatiGenerali\DatiSal
+     */
+    public function testDatiSal()
+    {
+        $datiDdt = new DatiGenerali\DatiSal(1);
+        $this->assertInstanceOf(DatiGenerali\DatiSal::class, $datiDdt);
+        return $datiDdt;
+    }
+
+    /**
      * @depends testDatiDdt
+     * @depends testDatiSal
      * @param DatiGenerali\DatiDdt $datiDdt
      * @return DatiGenerali
      */
-    public function testCreateDatiGenerali(DatiGenerali\DatiDdt $datiDdt)
+    public function testCreateDatiGenerali(DatiGenerali\DatiDdt $datiDdt, DatiGenerali\DatiSal $datiSal)
     {
         $datiGenerali = new DatiGenerali(
             TipoDocumento::Fattura,
@@ -136,6 +148,7 @@ class FatturaSempliceTest extends TestCase
             122
         );
         $datiGenerali->setDatiDdt($datiDdt);
+        $datiGenerali->setDatiSal($datiSal);
         $datiGenerali->Causale = "Fattura di prova";
         $this->assertInstanceOf(DatiGenerali::class, $datiGenerali);
         return $datiGenerali;
@@ -180,14 +193,26 @@ class FatturaSempliceTest extends TestCase
     }
 
     /**
+     * @return DatiVeicoli
+     */
+    public function testCreateDatiVeicoli()
+    {
+        $datiVeicoli = new DatiVeicoli(date('Y-m-d'), '100 KM');
+        $this->assertInstanceOf(DatiVeicoli::class, $datiVeicoli);
+        return $datiVeicoli;
+    }
+
+    /**
      * @depends testSetCessionarioCommittente
      * @depends testCreateDatiGenerali
      * @depends testCreateDatiPagamento
      * @depends testCreateDettaglioLinee
+     * @depends testCreateDatiVeicoli
      * @param FatturaElettronicaFactory $factory
      * @param DatiGenerali $datiGenerali
      * @param DatiPagamento $datiPagamento
      * @param DettaglioLinee $dettaglioLinee
+     * @param DatiVeicoli $datiVeicoli
      * @return \Deved\FatturaElettronica\FatturaElettronica
      * @throws \Exception
      */
@@ -195,9 +220,18 @@ class FatturaSempliceTest extends TestCase
         FatturaElettronicaFactory $factory,
         DatiGenerali $datiGenerali,
         DatiPagamento $datiPagamento,
-        DettaglioLinee $dettaglioLinee
+        DettaglioLinee $dettaglioLinee,
+        DatiVeicoli $datiVeicoli
     ) {
-        $fattura = $factory->create($datiGenerali, $datiPagamento, $dettaglioLinee, '12345');
+        $fattura = $factory->create(
+            $datiGenerali,
+            $datiPagamento,
+            $dettaglioLinee,
+            '12345',
+            null,
+            null,
+            $datiVeicoli
+        );
         $this->assertInstanceOf(FatturaElettronica::class, $fattura);
         return $fattura;
     }
@@ -211,7 +245,6 @@ class FatturaSempliceTest extends TestCase
         $name = $fattura->getFileName();
         $this->assertTrue(strlen($name) > 5);
     }
-
 
     /**
      * @depends testCreateFattura

--- a/tests/FatturaSempliceTest.php
+++ b/tests/FatturaSempliceTest.php
@@ -111,6 +111,12 @@ class FatturaSempliceTest extends TestCase
         return $factory;
     }
 
+    public function testDatiDdt()
+    {
+        $datiDdt = new DatiGenerali\DatiDdt('A1', '2018-11-10', ['1', '2']);
+        $datiDdt->addDatiDdt(new DatiGenerali\DatiDdt('A2', '2018-12-9', ['3', '4']));
+    }
+
     /**
      * @return DatiGenerali
      */

--- a/tests/FatturaSempliceTest.php
+++ b/tests/FatturaSempliceTest.php
@@ -136,6 +136,7 @@ class FatturaSempliceTest extends TestCase
             122
         );
         $datiGenerali->setDatiDdt($datiDdt);
+        $datiGenerali->Causale = "Fattura di prova";
         $this->assertInstanceOf(DatiGenerali::class, $datiGenerali);
         return $datiGenerali;
     }

--- a/xsd/fattura_pa_1.2.1.xsd
+++ b/xsd/fattura_pa_1.2.1.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
 	xmlns="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"


### PR DESCRIPTION
In caso di fattura PA la versione XML non dev'essere FRP12 ma FPA12.

Ho modificato **FatturaElettronica.php** e **DatiTrasmissione.php** aggiungendo una classe per richiamare il tipo fattura

`$writer->writeAttribute('versione', $this->fatturaElettronicaHeader->datiTrasmissione->tipoFattura());`
`public function tipoFattura(){
        return $this->formatoTrasmissione;
    }`
