### PR TITLE
Aggiunti supporto ai tipi DatiDocumentiCorrelati

### DIFF
--- a/src/Codifiche/TipoDocumentoCorrelato.php
+++ b/src/Codifiche/TipoDocumentoCorrelato.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\Codifiche;
+
+
+abstract class TipoDocumentoCorrelato
+{
+    const OrdineAcquisto = 'DatiOrdineAcquisto';
+    const Contratto = 'DatiDocumentoCorrelato';
+    const Convenzione = 'DatiConvenzione';
+    const Ricezione = 'DatiRicezione';
+    const FattureCollegate = 'DatiFattureCollegate';
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -15,6 +15,7 @@ use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGener
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiContratto;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiConvenzione;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiDdt;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiDocumentoCorrelato;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiRitenuta;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiCassaPrevidenziale;
 use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali\DatiSal;
@@ -54,6 +55,8 @@ class DatiGenerali implements XmlSerializableInterface
     protected $datiSal;
     /** @var DatiConvenzione */
     protected $datiConvenzione;
+    /** @var DatiDocumentoCorrelato */
+    protected $datiDocumentoCorrelati;
 
 
     /**
@@ -92,6 +95,11 @@ class DatiGenerali implements XmlSerializableInterface
     public function setDatiContratto(DatiContratto $datiContratto)
     {
         $this->datiContratto = $datiContratto;
+    }
+
+    public function setDatiDocumentoCorrelato(DatiDocumentoCorrelato $datiDocumentoCorrelati)
+    {
+        $this->datiDocumentoCorrelati = $datiDocumentoCorrelati;
     }
 
     public function setDatiRitenuta(DatiRitenuta $datiRitenuta)
@@ -160,6 +168,9 @@ class DatiGenerali implements XmlSerializableInterface
         }
         if ($this->datiConvenzione) {
             $this->datiConvenzione->toXmlBlock($writer);
+        }
+        if ($this->datiDocumentoCorrelati) {
+            $this->datiDocumentoCorrelati->toXmlBlock($writer);
         }
         if ($this->datiSal) {
             $this->datiSal->toXmlBlock($writer);

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiDocumentoCorrelato.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiDocumentoCorrelato.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class DatiDocumentoCorrelato implements XmlSerializableInterface, \Countable, \Iterator
+{
+    use MagicFieldsTrait;
+
+    const OrdineAcquisto = 'DatiOrdineAcquisto';
+    const Contratto = 'DatiDocumentoCorrelato';
+    const Convenzione = 'DatiConvenzione';
+    const Ricezione = 'DatiRicezione';
+    const FattureCollegate = 'DatiFattureCollegate';
+
+    protected $tipoDocumentoCorrelato;
+    protected $datiDocumentiCorrelati = [];
+    protected $codiceCommessaConvenzione = '';
+    protected $currentIndex = 0;
+    protected $riferimentoNumeroLinee = [];
+    protected $idDocumento;
+    protected $numItem;
+    protected $codiceCUP;
+    protected $codiceCIG;
+    protected $data;
+
+    /**
+     * DatiDocumentoCorrelato constructor.
+     * @param string $idDocumento
+     * @param int[] $riferimentoNumeroLinee
+     */
+    public function __construct($tipoDocumentoCorrelato, $idDocumento, $data, $riferimentoNumeroLinee = [], $codiceCommessaConvenzione = '', $numItem = '', $codiceCUP = null, $codiceCIG = null)
+    {
+        $this->tipoDocumentoCorrelato = $tipoDocumentoCorrelato;
+        $this->idDocumento = $idDocumento;
+        $this->riferimentoNumeroLinee = $riferimentoNumeroLinee;
+        $this->data = $data;
+        $this->codiceCommessaConvenzione = $codiceCommessaConvenzione;
+        $this->numItem = $numItem;
+        $this->codiceCUP = $codiceCUP;
+        $this->codiceCIG = $codiceCIG;
+        $this->datiDocumentiCorrelati[] = $this;
+    }
+
+    public function addDatiDocumentoCorrelato(DatiDocumentoCorrelato $datiDocumentiCorrelati)
+    {
+        $this->datiDocumentiCorrelati[] = $datiDocumentiCorrelati;
+    }
+
+    /**
+     * Return the current element
+     * @link https://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     * @since 5.0.0
+     */
+    public function current()
+    {
+        return $this->datiDocumentiCorrelati[$this->currentIndex];
+    }
+
+    /**
+     * Move forward to next element
+     * @link https://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function next()
+    {
+        $this->currentIndex++;
+    }
+
+    /**
+     * Return the key of the current element
+     * @link https://php.net/manual/en/iterator.key.php
+     * @return mixed scalar on success, or null on failure.
+     * @since 5.0.0
+     */
+    public function key()
+    {
+        return $this->currentIndex;
+    }
+
+    /**
+     * Checks if current position is valid
+     * @link https://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     * @since 5.0.0
+     */
+    public function valid()
+    {
+        return isset($this->datiDocumentiCorrelati[$this->currentIndex]);
+    }
+
+    /**
+     * Rewind the Iterator to the first element
+     * @link https://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function rewind()
+    {
+        $this->currentIndex = 0;
+    }
+
+    /**
+     * Count elements of an object
+     * @link https://php.net/manual/en/countable.count.php
+     * @return int The custom count as an integer.
+     * </p>
+     * <p>
+     * The return value is cast to an integer.
+     * @since 5.1.0
+     */
+    public function count()
+    {
+        return count($this->datiDocumentiCorrelati);
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        /** @var DatiDocumentoCorrelato $block */
+        foreach ($this as $block) {
+            $writer->startElement($block->tipoDocumentoCorrelato);
+                if (count($block->riferimentoNumeroLinee) > 0) {
+                    /** @var int $linea */
+                    foreach ($block->riferimentoNumeroLinee as $linea) {
+                        $writer->writeElement('RiferimentoNumeroLinea', $linea);
+                    }
+                }
+                $writer->writeElement('IdDocumento', $block->idDocumento);
+                if ($block->data) {
+                    $writer->writeElement('Data', $block->data);
+                }
+                if ($block->numItem) {
+                    $writer->writeElement('NumItem', $block->numItem);
+                }
+                if ($block->codiceCommessaConvenzione) {
+                    $writer->writeElement('CodiceCommessaConvenzione', $block->codiceCommessaConvenzione);
+                }
+                if ($block->codiceCUP) {
+                    $writer->writeElement('CodiceCUP', $block->codiceCUP);
+                }
+                if ($block->codiceCIG) {
+                    $writer->writeElement('CodiceCIG', $block->codiceCIG);
+                }
+            $writer->endElement();
+        }
+        return $writer;
+    }
+}

--- a/tests/FatturaSempliceDocumentiCorrelatiTest.php
+++ b/tests/FatturaSempliceDocumentiCorrelatiTest.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\Tests;
+
+use Deved\FatturaElettronica\Codifiche\ModalitaPagamento;
+use Deved\FatturaElettronica\Codifiche\RegimeFiscale;
+use Deved\FatturaElettronica\Codifiche\TipoDocumento;
+use Deved\FatturaElettronica\Codifiche\TipoDocumentoCorrelato;
+use Deved\FatturaElettronica\FatturaElettronica;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\DettaglioLinee;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi\Linea;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiGenerali;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiPagamento;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiVeicoli;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\DatiAnagrafici;
+use Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaHeader\Common\Sede;
+use Deved\FatturaElettronica\FatturaElettronicaFactory;
+use Deved\FatturaElettronica\XmlValidator;
+use PHPUnit\Framework\TestCase;
+
+class FatturaSempliceDocumentiCorrelatiTest extends TestCase {
+  /**
+   * @return DatiAnagrafici
+   */
+  public function testCreateAnagraficaCedente() {
+    $anagraficaCedente = new DatiAnagrafici(
+      '12345678901',
+      'Acme SpA',
+      'IT',
+      '12345678901',
+      RegimeFiscale::Ordinario
+    );
+    $this->assertInstanceOf(DatiAnagrafici::class, $anagraficaCedente);
+    return $anagraficaCedente;
+  }
+
+  /**
+   * @return Sede
+   */
+  public function testCreateSedeCedente() {
+    $sedeCedente = new Sede('IT', 'Via Roma 10', '33018', 'Tarvisio', 'UD');
+    $this->assertInstanceOf(Sede::class, $sedeCedente);
+    return $sedeCedente;
+  }
+
+  /**
+   * @depends testCreateAnagraficaCedente
+   * @depends testCreateSedeCedente
+   * @param DatiAnagrafici $datiAnagrafici
+   * @param Sede $sede
+   * @return FatturaElettronicaFactory
+   */
+  public function testCreateFatturaElettronicaFactory(DatiAnagrafici $datiAnagrafici, Sede $sede) {
+    $feFactory = new FatturaElettronicaFactory(
+      $datiAnagrafici,
+      $sede,
+      '+39123456789',
+      'info@deved.it'
+    );
+    $this->assertInstanceOf(FatturaElettronicaFactory::class, $feFactory);
+    return $feFactory;
+  }
+
+  /**
+   * @return DatiAnagrafici
+   */
+  public function testCreateAnagraficaCessionario() {
+    $anaCessionario = new DatiAnagrafici('XYZYZX77M04H888K', 'Pinco Palla');
+    $this->assertInstanceOf(DatiAnagrafici::class, $anaCessionario);
+    return $anaCessionario;
+  }
+
+  /**
+   * @return Sede
+   */
+  public function testCreateSedeCessionario() {
+    $sedeCessionario = new Sede('IT', 'Via Diaz 35', '33018', 'Tarvisio', 'UD');
+    $this->assertInstanceOf(Sede::class, $sedeCessionario);
+    return $sedeCessionario;
+  }
+
+  /**
+   * @depends testCreateFatturaElettronicaFactory
+   * @depends testCreateAnagraficaCessionario
+   * @depends testCreateSedeCessionario
+   * @param FatturaElettronicaFactory $factory
+   * @param DatiAnagrafici $datiAnagrafici
+   * @param Sede $sede
+   * @return FatturaElettronicaFactory
+   */
+  public function testSetCessionarioCommittente(
+    FatturaElettronicaFactory $factory,
+    DatiAnagrafici $datiAnagrafici,
+    Sede $sede
+  ) {
+    $factory->setCessionarioCommittente($datiAnagrafici, $sede);
+    $this->assertInstanceOf(FatturaElettronicaFactory::class, $factory);
+    return $factory;
+  }
+
+  /**
+   * @return DatiGenerali\DatiDdt
+   */
+  public function testDatiDdt() {
+    $datiDdt = new DatiGenerali\DatiDdt('A1', '2018-11-10', ['1', '2']);
+    $datiDdt->addDatiDdt(new DatiGenerali\DatiDdt('A2', '2018-12-09', ['3', '4']));
+    $this->assertInstanceOf(DatiGenerali\DatiDdt::class, $datiDdt);
+    return $datiDdt;
+  }
+
+  /**
+   * @return DatiGenerali\DatiDocumentoCorrelato
+   */
+  public function testDatiDocumentiCorrelati() {
+    $datiDocumentoCorrelato = new DatiGenerali\DatiDocumentoCorrelato(TipoDocumentoCorrelato::OrdineAcquisto, 'PO-00001', '2018-11-11', ['1', '2']);
+    $datiDocumentoCorrelato->addDatiDocumentoCorrelato(new DatiGenerali\DatiDocumentoCorrelato(TipoDocumentoCorrelato::Convenzione, 'PO-00001', '2021-11-11', ['3', '4']));
+    $this->assertInstanceOf(DatiGenerali\DatiDocumentoCorrelato::class, $datiDocumentoCorrelato);
+    return $datiDocumentoCorrelato;
+  }
+
+  /**
+   * @return DatiGenerali\DatiSal
+   */
+  public function testDatiSal() {
+    $datiDdt = new DatiGenerali\DatiSal(1);
+    $this->assertInstanceOf(DatiGenerali\DatiSal::class, $datiDdt);
+    return $datiDdt;
+  }
+
+  /**
+   * @depends testDatiDdt
+   * @depends testDatiSal
+   * @depends testDatiDocumentiCorrelati
+   * @param DatiGenerali\DatiDdt $datiDdt
+   * @return DatiGenerali
+   */
+  public function testCreateDatiGenerali(DatiGenerali\DatiDdt $datiDdt, DatiGenerali\DatiSal $datiSal, DatiGenerali\DatiDocumentoCorrelato $datiDocumentoCorrelato) {
+    $datiGenerali = new DatiGenerali(
+      TipoDocumento::Fattura,
+      '2018-11-22',
+      '2018221111',
+      122
+    );
+    $datiGenerali->setDatiDdt($datiDdt);
+    $datiGenerali->setDatiSal($datiSal);
+    $datiGenerali->setDatiDocumentoCorrelato($datiDocumentoCorrelato);
+    $datiGenerali->Causale = "Fattura di prova";
+    $this->assertInstanceOf(DatiGenerali::class, $datiGenerali);
+    return $datiGenerali;
+  }
+
+  /**
+   * @return DatiPagamento
+   */
+  public function testCreateDatiPagamento() {
+    $datiPagamento = new DatiPagamento(
+      ModalitaPagamento::SEPA_CORE,
+      '2018-11-30',
+      122
+    );
+    $this->assertInstanceOf(DatiPagamento::class, $datiPagamento);
+    return $datiPagamento;
+  }
+
+  /**
+   * @return array
+   */
+  public function testCreateLinee() {
+    $linee = [];
+    $linee[] = new Linea('Articolo1', 50, 'ABC');
+    $linee[] = new Linea('Articolo2', 25, '3286340685115', 2, 'pz', 22.00, 'EAN');
+    $this->assertCount(2, $linee);
+    return $linee;
+  }
+
+  /**
+   * @param array $linee
+   * @depends testCreateLinee
+   * @return DettaglioLinee
+   */
+  public function testCreateDettaglioLinee($linee) {
+    $dettaglioLinee = new DettaglioLinee($linee);
+    $this->assertInstanceOf(DettaglioLinee::class, $dettaglioLinee);
+    return $dettaglioLinee;
+  }
+
+  /**
+   * @return DatiVeicoli
+   */
+  public function testCreateDatiVeicoli() {
+    $datiVeicoli = new DatiVeicoli(date('Y-m-d'), '100 KM');
+    $this->assertInstanceOf(DatiVeicoli::class, $datiVeicoli);
+    return $datiVeicoli;
+  }
+
+  /**
+   * @depends testSetCessionarioCommittente
+   * @depends testCreateDatiGenerali
+   * @depends testCreateDatiPagamento
+   * @depends testCreateDettaglioLinee
+   * @depends testCreateDatiVeicoli
+   * @param FatturaElettronicaFactory $factory
+   * @param DatiGenerali $datiGenerali
+   * @param DatiPagamento $datiPagamento
+   * @param DettaglioLinee $dettaglioLinee
+   * @param DatiVeicoli $datiVeicoli
+   * @return \Deved\FatturaElettronica\FatturaElettronica
+   * @throws \Exception
+   */
+  public function testCreateFattura(
+    FatturaElettronicaFactory $factory,
+    DatiGenerali $datiGenerali,
+    DatiPagamento $datiPagamento,
+    DettaglioLinee $dettaglioLinee,
+    DatiVeicoli $datiVeicoli
+  ) {
+    $fattura = $factory->create(
+      $datiGenerali,
+      $datiPagamento,
+      $dettaglioLinee,
+      '12345',
+      null,
+      null,
+      $datiVeicoli
+    );
+    $this->assertInstanceOf(FatturaElettronica::class, $fattura);
+    return $fattura;
+  }
+
+  /**
+   * @depends testCreateFattura
+   * @param FatturaElettronica $fattura
+   */
+  public function testGetNomeFattura(FatturaElettronica $fattura) {
+    $name = $fattura->getFileName();
+    $this->assertTrue(strlen($name) > 5);
+  }
+
+  /**
+   * @depends testCreateFattura
+   * @param FatturaElettronica $fattura
+   * @throws \Exception
+   */
+  public function testXmlSchemaFattura(FatturaElettronica $fattura) {
+    $this->assertTrue($fattura->verifica());
+  }
+}


### PR DESCRIPTION
Chiude #87 

Mantenute le classi `DatiContratto` e `DatiConvenzione` per retrocompatibilità.