### PR TITLE
Aggiunta impostazione decimali per linea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.17] - 2021-08-25
+### Added
+- Aggiunta impostazione decimali per linea #89 by danielebuso
+
 ## [1.1.16] - 2021-05-28
 ### Added
 - Aggiunti supporto ai tipi DatiDocumentiCorrelati #88 by danielebuso

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -48,6 +48,7 @@ class Linea implements XmlSerializableInterface
      * @param string $unitaMisura
      * @param float $aliquotaIva
      * @param string $codiceTipo
+     * @param int $decimaliLinea
      */
     public function __construct(
         $descrizione,

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -35,6 +35,8 @@ class Linea implements XmlSerializableInterface
     protected $codiceTipo;
     /** @var ScontoMaggiorazione[]|null */
     protected $scontoMaggiorazione = [];
+    /** @var int */
+    protected $decimaliLinea;
 
 
     /**
@@ -54,7 +56,8 @@ class Linea implements XmlSerializableInterface
         $quantita = null,
         $unitaMisura = 'pz',
         $aliquotaIva = 22.00,
-        $codiceTipo = 'FORN'
+        $codiceTipo = 'FORN',
+        $decimaliLinea = 2
     ) {
         $this->codiceArticolo = $codiceArticolo;
         $this->descrizione = $descrizione;
@@ -63,6 +66,7 @@ class Linea implements XmlSerializableInterface
         $this->unitaMisura = $unitaMisura;
         $this->aliquotaIva = $aliquotaIva;
         $this->codiceTipo = $codiceTipo;
+        $this->decimaliLinea = $decimaliLinea;
     }
 
 
@@ -82,12 +86,12 @@ class Linea implements XmlSerializableInterface
         }
         $writer->writeElement('Descrizione', $this->descrizione);
         if ($this->quantita) {
-            $writer->writeElement('Quantita', fe_number_format($this->quantita, 2));
+            $writer->writeElement('Quantita', fe_number_format($this->quantita, $this->decimaliLinea));
             $writer->writeElement('UnitaMisura', $this->unitaMisura);
         }
         $this->writeXmlField('DataInizioPeriodo', $writer);
         $this->writeXmlField('DataFinePeriodo', $writer);
-        $writer->writeElement('PrezzoUnitario', fe_number_format($this->prezzoUnitario, 2));
+        $writer->writeElement('PrezzoUnitario', fe_number_format($this->prezzoUnitario, $this->decimaliLinea));
         foreach ($this->scontoMaggiorazione as $item) {
             $item->toXmlBlock($writer);
         }
@@ -112,7 +116,7 @@ class Linea implements XmlSerializableInterface
             $totale = $item->applicaScontoMaggiorazione($totale);
         }
         if ($format) {
-            return fe_number_format($totale, 2);
+            return fe_number_format($totale, $this->decimaliLinea);
         }
         return $totale;
     }


### PR DESCRIPTION
Chiude #49

Aggiunto il parametro `(int) $decimaliLinea` nel costruttore della classe `Linea` per poter specificare una quantità personalizzata di decimali. Mantenuto il valore di default a `2` per retrocompatibilità e comodità.