### PR TITLE
Fix ordine Causale in blocco DatiGenerali

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.19] - 2021-09-02
+### Fixed
+- Sistemato ordine Causale fattura #91 by danielebuso
+
 ## [1.1.18] - 2021-08-26
 ### Added
 - Aggiunto Arrotondamento e TipoCessionePrestazione #90 by danielebuso

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiGenerali.php
@@ -156,10 +156,10 @@ class DatiGenerali implements XmlSerializableInterface
         if ($this->scontoMaggiorazione) {
             $this->scontoMaggiorazione->toXmlBlock($writer);
         }
+        $writer->writeElement('ImportoTotaleDocumento', fe_number_format($this->importoTotaleDocumento, 2));
         if ($this->causale) {
             $writer->writeElement('Causale', $this->causale);
         }
-        $writer->writeElement('ImportoTotaleDocumento', fe_number_format($this->importoTotaleDocumento, 2));
         $this->writeXmlFields($writer);
         $writer->endElement();
 


### PR DESCRIPTION
L'elemento `Causale` è stato spostato sotto l'elemento `ImportoTotaleDocumento` come da specifiche xsd FatturaPA 1.2.1 incluse nella libreria.