### PR TITLE
Fix DatiContratto su DatiDocumentiCorrelati

### DIFF
--- a/src/Codifiche/TipoDocumentoCorrelato.php
+++ b/src/Codifiche/TipoDocumentoCorrelato.php
@@ -15,7 +15,7 @@ namespace Deved\FatturaElettronica\Codifiche;
 abstract class TipoDocumentoCorrelato
 {
     const OrdineAcquisto = 'DatiOrdineAcquisto';
-    const Contratto = 'DatiDocumentoCorrelato';
+    const Contratto = 'DatiContratto';
     const Convenzione = 'DatiConvenzione';
     const Ricezione = 'DatiRicezione';
     const FattureCollegate = 'DatiFattureCollegate';


### PR DESCRIPTION
Al momento il tipo documento correlato "Contratto" presenta il valore `DatiDocumentoCorrelato` invece di `DatiContratto`