### PR TITLE
Hotfix formato trasmissione FPR12/FPA12 in nodo radice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.23] - 2022-04-13
+### Fixed
+- Hotfix formato trasmissione FPR12/FPA12 in nodo radice #99 by danielebuso
+
+## [1.1.22] - 2022-03-02
+### Fixed
+- Fix DatiContratto su DatiDocumentiCorrelati #98 by danielebuso
+
 ## [1.1.21] - 2021-10-06
 ### Fixed
 - Fix sconto e maggiorazione su importo #93 by danielebuso

--- a/src/FatturaElettronica.php
+++ b/src/FatturaElettronica.php
@@ -43,7 +43,7 @@ class FatturaElettronica implements XmlSerializableInterface, FatturaElettronica
     public function toXmlBlock(\XMLWriter $writer)
     {
         $writer->startElementNS('p', 'FatturaElettronica', null);
-        $writer->writeAttribute('versione', 'FPR12');
+        $writer->writeAttribute('versione', $this->fatturaElettronicaHeader->datiTrasmissione->formatoTrasmissione);
         $writer->writeAttributeNS('xmlns', 'ds', null, 'http://www.w3.org/2000/09/xmldsig#');
         $writer->writeAttributeNS('xmlns', 'p', null, 'http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2');
         $writer->writeAttributeNS('xmlns', 'xsi', null, 'http://www.w3.org/2001/XMLSchema-instance');

--- a/src/FatturaElettronica/FatturaElettronicaHeader/DatiTrasmissione.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/DatiTrasmissione.php
@@ -27,7 +27,7 @@ class DatiTrasmissione implements XmlSerializableInterface
     /** @var string */
     public $progressivoInvio;
     /** @var string */
-    protected $formatoTrasmissione;
+    public $formatoTrasmissione;
     /** @var string */
     protected $codiceDestinatario;
     /** @var array  */


### PR DESCRIPTION
Al momento le fatture PA vengono rifiutate dal sistema di interscambio in quanto nella libreria è hardcodato `FPR12` come versione nel nodo radice `FatturaElettronica`.

Questo hotfix fa si che quel valore venga recuperato dai `DatiTrasmissione` ovvero dove viene specificato se è una fattura PA o meno.

La modifica dovrebbe essere retrocompatibile in quanto sia `FatturaElettronicaHeader` che `DatiTrasmissione` devono  essere valorizzati facendo parte dei costruttori.