### PR TITLE
Hotfix numero decimali quantità linea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.25] - 2022-08-29
+### Fixed
+-  Hotfix numero decimali quantità linea #103 by danielebuso
+
+## [1.1.24] - 2022-05-23
+### Fixed
+-  Aggiunta gestione natura iva #102 by @snipershady
 
 ## [1.1.23] - 2022-04-13
 ### Fixed

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -99,7 +99,7 @@ class Linea implements XmlSerializableInterface
         }
         $writer->writeElement('Descrizione', $this->descrizione);
         if ($this->quantita) {
-            $writer->writeElement('Quantita', fe_number_format($this->quantita, $this->decimaliLinea));
+            $writer->writeElement('Quantita', fe_number_format($this->quantita, $this->decimaliQuantita()));
             $writer->writeElement('UnitaMisura', $this->unitaMisura);
         }
         $this->writeXmlField('DataInizioPeriodo', $writer);
@@ -135,6 +135,16 @@ class Linea implements XmlSerializableInterface
             $totale = $item->applicaScontoMaggiorazione($totale, $quantita, $format ? $this->decimaliLinea : null);
         }
         return fe_number_format($totale, $this->decimaliLinea);
+    }
+
+    /**
+     * Restituisce il numero di decimali della quantita
+     *
+     * @return int
+     */
+    public function decimaliQuantita()
+    {
+        return max(min(strlen(substr(strrchr($this->quantita, "."), 1)), 8), 2);
     }
 
     /**


### PR DESCRIPTION
Al momento la quantità viene arrotondata al numero di decimali utilizzati per gli importi, questo è un errore in quanto le due cose non sono per forza collegate, la specifica dell'agenzia delle entrate permette difatti di specificare fino a 8 decimali nel campo quantità con un minimo di due.

La modifica dovrebbe essere genericamente retrocompatibile in caso di quantità con un numero di decimali uguale o inferiore a quelli utilizzati per gli importi, in caso di numero di decimali superiore al momento le fatture dovrebbero venire scartate dallo SdI.