### PR TITLE
Aggiunto RiferimentoAmministrazione nel nodo CedentePrestatore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.26] - 2023-02-02
+### Added
+-  Aggiunto RiferimentoAmministrazione nel nodo CedentePrestatore #107 by danielebuso
+
 ## [1.1.25] - 2022-08-29
 ### Fixed
 -  Hotfix numero decimali quantità linea #103 by danielebuso

--- a/src/FatturaAdapter.php
+++ b/src/FatturaAdapter.php
@@ -124,6 +124,14 @@ class FatturaAdapter implements FatturaElettronicaInterface
     }
 
     /**
+     * @param string $riferimentoAmministrazione
+     */
+    public function setRiferimentoAmministrazione($riferimentoAmministrazione)
+    {
+        $this->fatturaElettronicaHeader->cedentePrestatore->setRiferimentoAmministrazione($riferimentoAmministrazione);
+    }
+
+    /**
      * Verifica l'xml della fattura
      * @return bool
      * @throws \Exception

--- a/src/FatturaElettronica.php
+++ b/src/FatturaElettronica.php
@@ -106,4 +106,12 @@ class FatturaElettronica implements XmlSerializableInterface, FatturaElettronica
     {
         $this->fatturaElettronicaHeader->cedentePrestatore->setIscrizioneRea($iscrizioneRea);
     }
+
+    /**
+     * @param string $riferimentoAmministrazione
+     */
+    public function setRiferimentoAmministrazione($riferimentoAmministrazione)
+    {
+        $this->fatturaElettronicaHeader->cedentePrestatore->setRiferimentoAmministrazione($riferimentoAmministrazione);
+    }
 }

--- a/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
+++ b/src/FatturaElettronica/FatturaElettronicaHeader/CedentePrestatore.php
@@ -26,6 +26,7 @@ class CedentePrestatore implements XmlSerializableInterface
     protected $sede;
     /** @var IscrizioneRea */
     protected $iscrizioneRea;
+    protected $riferimentoAmministrazione;
 
 
     /**
@@ -53,6 +54,14 @@ class CedentePrestatore implements XmlSerializableInterface
     }
 
     /**
+     * @param string $riferimentoAmministrazione
+     */
+    public function setRiferimentoAmministrazione($riferimentoAmministrazione)
+    {
+        $this->riferimentoAmministrazione = $riferimentoAmministrazione;
+    }
+
+    /**
      * @param \XMLWriter $writer
      * @return \XMLWriter
      */
@@ -63,6 +72,9 @@ class CedentePrestatore implements XmlSerializableInterface
             $this->sede->toXmlBlock($writer);
             if ($this->iscrizioneRea) {
                 $this->iscrizioneRea->toXmlBlock($writer);
+            }
+            if ($this->riferimentoAmministrazione) {
+                $writer->writeElement('RiferimentoAmministrazione', $this->riferimentoAmministrazione);
             }
             $this->writeXmlFields($writer);
         $writer->endElement();

--- a/src/FatturaElettronicaFactory.php
+++ b/src/FatturaElettronicaFactory.php
@@ -100,6 +100,14 @@ class FatturaElettronicaFactory
     }
 
     /**
+     * @param string $riferimentoAmministrazione
+     */
+    public function setRiferimentoAmministrazione($riferimentoAmministrazione)
+    {
+        $this->cedentePrestatore->setRiferimentoAmministrazione($riferimentoAmministrazione);
+    }
+
+    /**
      * @param IdTrasmittente $idTrasmittente
      */
     public function setIdTrasmittente(IdTrasmittente $idTrasmittente)


### PR DESCRIPTION
Aggiunta la possibilità di specificare il `RiferimentoAmministrazione` nel nodo `CedentePrestatore` tramite l'apposito metodo:

```php
// Set riferimento amministrazione
$fatturaElettronicaFactory->setRiferimentoAmministrazione('Testo di esempio');
```
La modifica non ha breaking changes in quanto va ad aggiungere un metodo che prima non esisteva senza modificare quelli esistenti.