### PR TITLE
Aggiunta la possibilità di specificare AltriDatiGestionali nei nodi DettaglioLinee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.27] - 2023-02-21
+### Added
+-   Aggiunta la possibilità di specificare AltriDatiGestionali nei nodi DettaglioLinee #108  by danielebuso
+
 ## [1.1.26] - 2023-02-02
 ### Added
 -  Aggiunto RiferimentoAmministrazione nel nodo CedentePrestatore #107 by danielebuso

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/AltriDatiGestionali.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/AltriDatiGestionali.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of deved/fattura-elettronica
+ *
+ * Copyright (c) Salvatore Guarino <sg@deved.it>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Deved\FatturaElettronica\FatturaElettronica\FatturaElettronicaBody\DatiBeniServizi;
+
+use Deved\FatturaElettronica\Traits\MagicFieldsTrait;
+use Deved\FatturaElettronica\XmlSerializableInterface;
+
+class AltriDatiGestionali implements XmlSerializableInterface
+{
+    use MagicFieldsTrait;
+
+    /** @var string */
+    public $tipoDato;
+    /** @var string */
+    public $riferimentoTesto;
+    /** @var string */
+    public $riferimentoNumero;
+    /** @var string */
+    public $riferimentoData;
+
+    /**
+     * AltriDatiGestionali constructor.
+     *
+     * @param $tipoDato
+     * @param null $riferimentoTesto
+     * @param null $riferimentoNumero
+     * @param null $riferimentoData
+     */
+    public function __construct($tipoDato, $riferimentoTesto = null, $riferimentoNumero = null, $riferimentoData = null)
+    {
+        $this->tipoDato = $tipoDato;
+        $this->riferimentoTesto = $riferimentoTesto;
+        $this->riferimentoNumero = $riferimentoNumero;
+        $this->riferimentoData = $riferimentoData;
+    }
+
+    /**
+     * @param \XMLWriter $writer
+     * @return \XMLWriter
+     */
+    public function toXmlBlock(\XMLWriter $writer)
+    {
+        $writer->startElement('AltriDatiGestionali');
+        $writer->writeElement('TipoDato', $this->tipoDato);
+        if ($this->riferimentoTesto) $writer->writeElement('RiferimentoTesto', $this->riferimentoTesto);
+        if ($this->riferimentoNumero) $writer->writeElement('RiferimentoNumero', $this->riferimentoNumero);
+        if ($this->riferimentoData) $writer->writeElement('RiferimentoData', $this->riferimentoData);
+        $this->writeXmlFields($writer);
+        $writer->endElement();
+        return $writer;
+    }
+
+}

--- a/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
+++ b/src/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/Linea.php
@@ -36,6 +36,8 @@ class Linea implements XmlSerializableInterface
     protected $codiceTipo;
     /** @var ScontoMaggiorazione[]|null */
     protected $scontoMaggiorazione = [];
+    /** @var AltriDatiGestionali[] */
+    protected $altriDatiGestionali = [];
     /** @var int */
     protected $decimaliLinea;
     /** @var string */
@@ -116,6 +118,9 @@ class Linea implements XmlSerializableInterface
             $writer->writeElement('Natura', $this->naturaIva);
         }    
         $this->writeXmlFields($writer);
+        foreach ($this->altriDatiGestionali as $item) {
+            $item->toXmlBlock($writer);
+        }
         $writer->endElement();
         return $writer;
     }
@@ -172,5 +177,10 @@ class Linea implements XmlSerializableInterface
     public function setScontoMaggiorazione(ScontoMaggiorazione $scontoMaggiorazione)
     {
         $this->scontoMaggiorazione[] = $scontoMaggiorazione;
+    }
+
+    public function setAltriDatiGestionali(AltriDatiGestionali $altriDatiGestionali)
+    {
+        $this->altriDatiGestionali[] = $altriDatiGestionali;
     }
 }


### PR DESCRIPTION
Aggiunta la possibilità di specificare uno o più blocchi `AltriDatiGestionali` nei nodi `DettaglioLinee` tramite l'apposito metodo:

```php
// Set altri dati gestionali
$datiLinea->setAltriDatiGestionali(new AltriDatiGestionali(
    'N.DOC.COMM', // TipoDato
    '1234', // RiferimentoTesto (or null)
    '12.34', // RiferimentoNumero (or null)
    '2023-02-21' // RiferimentoData (or null)
));
```

La chiamata al metodo `setAltriDatiGestionali` è ripetibile e durante la generazione dell'xml verranno aggiunti al `DettaglioLinee` tutti i blocchi `AltriDatiGestionali` passati.

La modifica non ha breaking changes in quanto va ad aggiungere un metodo che prima non esisteva senza modificare quelli esistenti.
